### PR TITLE
feat: Add GitHub Action to update weekly podcast JSON

### DIFF
--- a/.github/workflows/update-weekly-json.yml
+++ b/.github/workflows/update-weekly-json.yml
@@ -1,0 +1,37 @@
+name: Update Weekly Podcast JSON
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Run at 00:00 UTC every Monday
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  update_json:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to commit changes
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest # or specify a version like "1.0.0"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run update script
+        run: bun run ./scripts/updateWeeklyJson.ts # Adjusted path for clarity
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: Update weekly podcast JSON'
+          branch: main # Or your default branch
+          file_pattern: 'results/*.json' # Only commit changes in the results directory
+          commit_user_name: 'github-actions[bot]'
+          commit_user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+```

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "DEBUG=* bun --watch src/index.ts",
     "build": "bun build src/index.ts --target bun --outdir ./dist",
+    "update-json": "bun run ./scripts/updateWeeklyJson.ts",
     "start": "NODE_ENV=production bun dist/index.js",
     "lint": "eslint",
     "lint:fix": "eslint --fix",

--- a/scripts/updateWeeklyJson.ts
+++ b/scripts/updateWeeklyJson.ts
@@ -1,0 +1,24 @@
+import { fetchLastWeekPodcast } from '../src/service/lastweek';
+
+async function main() {
+  console.log('Starting weekly podcast update...');
+  try {
+    const result = await fetchLastWeekPodcast();
+    if (result.status) {
+      console.log(`Successfully updated podcast data: ${result.msg}`);
+      if (result.data) {
+        console.log(`Week Number: ${result.data.weekNumber}`);
+        console.log(`File created/updated: results/${result.data.weekNumber}.json`);
+      } else if (result.file) {
+        // Case where file already existed
+        console.log(`File already existed: results/${result.file}`);
+      }
+    } else {
+      console.error(`Failed to update podcast data: ${result.msg}`);
+    }
+  } catch (error) {
+    console.error('An unexpected error occurred during the weekly update:', error);
+  }
+}
+
+main();

--- a/scripts/updateWeeklyJson.ts
+++ b/scripts/updateWeeklyJson.ts
@@ -18,6 +18,7 @@ async function main() {
     }
   } catch (error) {
     console.error('An unexpected error occurred during the weekly update:', error);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
This commit introduces a GitHub Action that runs every Monday to fetch podcast data for the previous week and updates a JSON file in the 'results' directory.

Key changes:
- Added `scripts/updateWeeklyJson.ts`: A script that uses the existing `fetchLastWeekPodcast` service to generate the weekly JSON.
- Added `.github/workflows/update-weekly-json.yml`: The GitHub Action workflow that schedules and runs the update script. It checks out the code, sets up Bun, installs dependencies, runs the script, and commits any changes to 'results/*.json'.
- Updated `package.json`: Added an `update-json` script for manual execution of the weekly update.