### PR TITLE
feat: Add automatic RSS feed generation

### DIFF
--- a/.github/workflows/download-mp3s.yml
+++ b/.github/workflows/download-mp3s.yml
@@ -3,7 +3,7 @@ name: Download Podcasts to S3
 on:
   workflow_dispatch: # Allows manual triggering
   workflow_run:
-    workflows: ["Update Weekly Podcast JSON"] # Name of the workflow that generates the JSON
+    workflows: [Update Weekly Podcast JSON] # Name of the workflow that generates the JSON
     types:
       - completed
     branches:
@@ -41,17 +41,16 @@ jobs:
       # shell touch *
       - name: touch files
         run: touch ./temp-media/*
-    
+
       - name: upload files to OSS
         uses: fangbinwei/aliyun-oss-website-action@v1
         with:
-            accessKeyId: ${{ secrets.S3_ACCESS_KEY_ID }}
-            accessKeySecret: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-            bucket: ${{ secrets.S3_BUCKET_NAME }}
-            # use your own endpoint
-            endpoint: oss-cn-beijing.aliyuncs.com
-            folder: temp-media
-           
+          accessKeyId: ${{ secrets.S3_ACCESS_KEY_ID }}
+          accessKeySecret: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          bucket: ${{ secrets.S3_BUCKET_NAME }}
+          # use your own endpoint
+          endpoint: oss-cn-beijing.aliyuncs.com
+          folder: temp-media
 
       # - name: Upload temp-media folder to S3
       #   uses: jakejarvis/s3-sync-action@v0.5.1

--- a/.github/workflows/update-weekly-json.yml
+++ b/.github/workflows/update-weekly-json.yml
@@ -25,12 +25,15 @@ jobs:
       - name: Run update script
         run: bun run ./scripts/updateWeeklyJson.ts # Adjusted path for clarity
 
+      - name: Generate RSS XML
+        run: bun run generate-rss
+
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: 'chore: Update weekly podcast JSON'
+          commit_message: 'chore: Update weekly podcast JSON and RSS feed' # Updated commit message
           branch: main # Or your default branch
-          file_pattern: 'results/*.json' # Only commit changes in the results directory
+          file_pattern: 'results/*.json rss.xml' # Updated file_pattern
           commit_user_name: 'github-actions[bot]'
           commit_user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,5 +6,5 @@ export default antfu({
     'node/prefer-global/process': 'off',
     'no-console': 'off',
   },
-  ignores: ['results/**/*.json'],
+  ignores: ['results/**/*.json', '.vscode/**/*'],
 })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "bun test",
     "docker:build": "docker build -t elysia_docker:latest -t elysia_docker:$(date +%Y%m%d%H) .",
     "docker:run": "docker run -d -p 3000:3000 --name elysia_docker  elysia_docker:latest",
-    "generate-rss": "bun run ./scripts/generateRssXml.ts"
+    "generate-rss": "DEBUG=* bun run ./scripts/generateRssXml.ts"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint:fix": "eslint --fix",
     "test": "bun test",
     "docker:build": "docker build -t elysia_docker:latest -t elysia_docker:$(date +%Y%m%d%H) .",
-    "docker:run": "docker run -d -p 3000:3000 --name elysia_docker  elysia_docker:latest"
+    "docker:run": "docker run -d -p 3000:3000 --name elysia_docker  elysia_docker:latest",
+    "generate-rss": "bun run ./scripts/generateRssXml.ts"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/results/22.xml
+++ b/results/22.xml
@@ -1,0 +1,1614 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <atom:link href="https://&lt;your-domain-here&gt;/rss.xml" rel="self" type="application/rss+xml"/>
+    <title>Weekly Podcast Updates</title>
+    <link>https://&lt;your-project-link-here&gt;</link>
+    <language>en-us</language>
+    <description>Weekly digest of podcast episodes from week 22, starting 2025-05-26.</description>
+    <lastBuildDate>Tue, 03 Jun 2025 14:51:05 GMT</lastBuildDate>
+    <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+    <item>
+      <title>The Myth of Perfect Code w/ Marc Backes</title>
+      <link>https://art19.com/shows/whiskey-web-and-whatnot</link>
+      <description>This week, Robbie and Chuck talk with Marc Backes about Vue vs. React, work-life balance, and the realities of messy codebases. They also sip an Evan Williams Single Barrel, debate inbox zero, and discuss Marc’s adventures in coffee roasting and pilot training.
+In this episode:
+
+(00:00) - Intro
+(01:45) - Whiskey review and rating: Evan Williams Single Barrel
+(09:03) - Hot Take: Inferred types vs explicit types
+(10:04) - Hot Take: Tailwind vs vanilla CSS
+(10:59) - Hot Take: Git Rebase vs Git Merge
+(11:27) - Nested ternaries?
+(15:58) - Real code vs ideal code
+(21:43) - Why work/life balance matters
+(30:28) - Why Marc chose Vue over React
+(31:19) - Ryan Reynolds speaking at Post/Con
+(32:40) - Render Atlanta and upcoming conferences
+(33:48) - Marc's connection to Mexico
+(34:54) - Discussing different foods
+(37:09) - Marc's inbox zero strategy
+(40:26) - Learning to fly
+(44:06) - Roasting coffee as a hobby
+(46:13) - Personal branding and standing out
+(51:19) - Plugs
+
+Links
+
+Evan Williams Single Barrel: https://evanwilliams.com/single-barrel
+Vue: https://vuejs.org/
+Nuxt: https://nuxt.com/
+Norlan: https://norlanglass.com/
+Nintendo: https://www.nintendo.com/
+Switch 2: https://www.nintendo.com/us/gaming-systems/switch-2/
+Double Double Oaked Woodford: https://www.woodfordreserve.com/whiskey/double-double-oaked/
+Typescript: https://www.typescriptlang.org/
+Tailwind CSS: https://tailwindcss.com/
+React: https://react.dev/
+jQuery: https://jquery.com/
+Ryan Reynolds: https://en.wikipedia.org/wiki/Ryan_Reynolds
+Post Con: https://postcon.postman.com/
+Aviation Gin: https://www.aviationgin.com/
+Mint Mobile: https://www.mintmobile.com/
+Render Conf: https://www.renderatl.com/
+Taco Bell: https://www.tacobell.com/
+Marc Backes - Achieving Inbox Zero: https://marc.dev/blog/inbox-zero
+Superhuman: https://superhuman.com/
+Vim: https://www.vim.org/
+Vue: https://vuejs.org/
+Vite: https://vite.dev/
+Terminal Coffee: https://www.terminal.shop/
+Dax: https://x.com/thdxr/
+Jack Daniel's: https://www.jackdaniels.com/
+Kelly Vaughn: https://x.com/kvlly
+
+Connect with Marc
+
+Website: https://marc.dev/
+X / Twitter: https://x.com/themarcba
+
+Connect with Chuck and Robbie
+
+Robbie Wagner: https://x.com/RobbieTheWagner
+Chuck Carpenter: https://x.com/CharlesWthe3rd
+
+Subscribe and stay in touch
+
+Website: https://whiskey.fm
+Apple Podcasts: https://podcasts.apple.com/us/podcast/whiskey-web-and-whatnot/id1552776603
+Spotify: https://open.spotify.com/show/19jiuHAqzeKnkleQUpZxDf
+Overcast: https://overcast.fm/itunes1552776603
+YouTube: https://www.youtube.com/@WhiskeyWebAndWhatnot
+
+Whiskey Web and Whatnot Merch
+Enjoying the podcast and want us to make more? Help support us by picking up some of our fresh merch at https://whiskey.fund.
+See Privacy Policy at https://art19.com/privacy and California Privacy Notice at https://art19.com/privacy#do-not-sell-my-info.</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://art19.com/shows/whiskey-web-and-whatnot</guid>
+      <enclosure url="https://rss.art19.com/episodes/44535030-2888-42a8-926c-d03a9a6aef2c.mp3?rss_browser=BAhJIg9yc3MtcGFyc2VyBjoGRVQ%3D--42d668516e215326a0c0e36404173d504b339a70" type="audio/mpeg" length="0"/>
+      <itunes:author>Whiskey Web and Whatnot: Web Development, Neat</itunes:author>
+      <itunes:summary>This week, Robbie and Chuck talk with Marc Backes about Vue vs. React, work-life balance, and the realities of messy codebases. They also sip an Evan Williams Single Barrel, debate inbox zero, and discuss Marc’s adventures in coffee roasting and pilot training.
+In this episode:
+
+(00:00) - Intro
+(01:45) - Whiskey review and rating: Evan Williams Single Barrel
+(09:03) - Hot Take: Inferred types vs explicit types
+(10:04) - Hot Take: Tailwind vs vanilla CSS
+(10:59) - Hot Take: Git Rebase vs Git Merge
+(11:27) - Nested ternaries?
+(15:58) - Real code vs ideal code
+(21:43) - Why work/life balance matters
+(30:28) - Why Marc chose Vue over React
+(31:19) - Ryan Reynolds speaking at Post/Con
+(32:40) - Render Atlanta and upcoming conferences
+(33:48) - Marc's connection to Mexico
+(34:54) - Discussing different foods
+(37:09) - Marc's inbox zero strategy
+(40:26) - Learning to fly
+(44:06) - Roasting coffee as a hobby
+(46:13) - Personal branding and standing out
+(51:19) - Plugs
+
+Links
+
+Evan Williams Single Barrel: https://evanwilliams.com/single-barrel
+Vue: https://vuejs.org/
+Nuxt: https://nuxt.com/
+Norlan: https://norlanglass.com/
+Nintendo: https://www.nintendo.com/
+Switch 2: https://www.nintendo.com/us/gaming-systems/switch-2/
+Double Double Oaked Woodford: https://www.woodfordreserve.com/whiskey/double-double-oaked/
+Typescript: https://www.typescriptlang.org/
+Tailwind CSS: https://tailwindcss.com/
+React: https://react.dev/
+jQuery: https://jquery.com/
+Ryan Reynolds: https://en.wikipedia.org/wiki/Ryan_Reynolds
+Post Con: https://postcon.postman.com/
+Aviation Gin: https://www.aviationgin.com/
+Mint Mobile: https://www.mintmobile.com/
+Render Conf: https://www.renderatl.com/
+Taco Bell: https://www.tacobell.com/
+Marc Backes - Achieving Inbox Zero: https://marc.dev/blog/inbox-zero
+Superhuman: https://superhuman.com/
+Vim: https://www.vim.org/
+Vue: https://vuejs.org/
+Vite: https://vite.dev/
+Terminal Coffee: https://www.terminal.shop/
+Dax: https://x.com/thdxr/
+Jack Daniel's: https://www.jackdaniels.com/
+Kelly Vaughn: https://x.com/kvlly
+
+Connect with Marc
+
+Website: https://marc.dev/
+X / Twitter: https://x.com/themarcba
+
+Connect with Chuck and Robbie
+
+Robbie Wagner: https://x.com/RobbieTheWagner
+Chuck Carpenter: https://x.com/CharlesWthe3rd
+
+Subscribe and stay in touch
+
+Website: https://whiskey.fm
+Apple Podcasts: https://podcasts.apple.com/us/podcast/whiskey-web-and-whatnot/id1552776603
+Spotify: https://open.spotify.com/show/19jiuHAqzeKnkleQUpZxDf
+Overcast: https://overcast.fm/itunes1552776603
+YouTube: https://www.youtube.com/@WhiskeyWebAndWhatnot
+
+Whiskey Web and Whatnot Merch
+Enjoying the podcast and want us to make more? Help support us by picking up some of our fresh merch at https://whiskey.fund.
+See Privacy Policy at https://art19.com/privacy and California Privacy Notice at https://art19.com/privacy#do-not-sell-my-info.</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Next.js Rendering Strategies and how they affect core web vitals</title>
+      <link>https://www.thisdot.co/blog/next-js-rendering-strategies-and-how-they-affect-core-web-vitals</link>
+      <description>When it comes to building fast and scalable web apps with Next.js, it’s important to understand how rendering works, especially with the App Router. Next.js organizes rendering around two main environments: the server and the client. On the server side, you’ll encounter three key strategies: Static Rendering, Dynamic Rendering, and Streaming. Each one comes with its own set of trade-offs and performance benefits, so knowing when to use which is crucial for delivering a great user experience.
+In this post, we'll break down each strategy, what it's good for, and how it impacts your site's performance, especially Core Web Vitals. We'll also explore hybrid approaches and provide practical guidance on choosing the right strategy for your use case.
+What Are Core Web Vitals?
+Core Web Vitals are a set of metrics defined by Google that measure real-world user experience on websites. These metrics play a major role in search engine rankings and directly affect how users perceive the speed and smoothness of your site.
+Largest Contentful Paint (LCP): This measures loading performance. It calculates the time taken for the largest visible content element to render. A good LCP is 2.5 seconds or less.
+Interaction to Next Paint (INP): This measures responsiveness to user input. A good INP is 200 milliseconds or less.
+Cumulative Layout Shift (CLS): This measures the visual stability of the page. It quantifies layout instability during load. A good CLS is 0.1 or less.
+If you want to dive deeper into Core Web Vitals and understand more about their impact on your website's performance, I recommend reading this detailed guide on  New Core Web Vitals and How They Work.
+Next.js Rendering Strategies and Core Web Vitals
+Let's explore each rendering strategy in detail:
+1. Static Rendering (Server Rendering Strategy)
+Static Rendering is the default for Server Components in Next.js. With this approach, components are rendered at build time (or during revalidation), and the resulting HTML is reused for each request. This pre-rendering happens on the server, not in the user's browser. Static rendering is ideal for routes where the data is not personalized to the user, and this makes it suitable for:
+Content-focused websites: Blogs, documentation, marketing pages
+E-commerce product listings: When product details don't change frequently
+SEO-critical pages: When search engine visibility is a priority
+High-traffic pages: When you want to minimize server load
+How Static Rendering Affects Core Web Vitals
+Largest Contentful Paint (LCP): Static rendering typically leads to excellent LCP scores (typically &lt; 1s). The Pre-rendered HTML can be cached and delivered instantly from CDNs, resulting in very fast delivery of the initial content, including the largest element. Also, there is no waiting for data fetching or rendering on the client.
+Interaction to Next Paint (INP): Static rendering provides a good foundation for INP, but doesn't guarantee optimal performance (typically ranges from 50-150 ms depending on implementation). While Server Components don't require hydration, any Client Components within the page still need JavaScript to become interactive. To achieve a very good INP score, you will need to make sure the Client Components within the page is minimal.
+Cumulative Layout Shift (CLS): While static rendering delivers the complete page structure upfront which can be very beneficial for CLS, achieving excellent CLS requires additional optimization strategies:
+Static HTML alone doesn't prevent layout shifts if resources load asynchronously
+Image dimensions must be properly specified to reserve space before the image loads
+Web fonts can cause text to reflow if not handled properly with font display strategies
+Dynamically injected content (ads, embeds, lazy-loaded elements) can disrupt layout stability
+CSS implementation significantly impacts CLS—immediate availability of styling information helps maintain visual stability
+Code Examples:
+Basic static rendering:
+// app/page.tsx (Server Component - Static Rendering by default)
+export default async function Page() {
+  const res = await fetch('https://api.example.com/static-data');
+  const data = await res.json();
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Static Content&lt;/h1&gt;
+      &lt;p&gt;{data.content}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}
+
+Static rendering with revalidation (ISR):
+// app/dashboard/page.tsx
+export default async function Dashboard() {
+  // Static data that revalidates every day
+  const siteStats = await fetch('https://api.example.com/site-stats', {
+    next: { revalidate: 86400 } // 24 hours
+  }).then(r =&gt; r.json());
+
+  // Data that revalidates every hour
+  const popularProducts = await fetch('https://api.example.com/popular-products', {
+    next: { revalidate: 3600 } // 1 hour
+  }).then(r =&gt; r.json());
+
+  // Data with a cache tag for on-demand revalidation
+  const featuredContent = await fetch('https://api.example.com/featured-content', {
+    next: { tags: ['featured'] }
+  }).then(r =&gt; r.json());
+
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      &lt;section className=&quot;stats&quot;&gt;
+        &lt;h2&gt;Site Statistics&lt;/h2&gt;
+        &lt;p&gt;Total Users: {siteStats.totalUsers}&lt;/p&gt;
+        &lt;p&gt;Total Orders: {siteStats.totalOrders}&lt;/p&gt;
+      &lt;/section&gt;
+
+      &lt;section className=&quot;popular&quot;&gt;
+        &lt;h2&gt;Popular Products&lt;/h2&gt;
+        &lt;ul&gt;
+          {popularProducts.map(product =&gt; (
+            &lt;li key={product.id}&gt;{product.name} - {product.sales} sold&lt;/li&gt;
+          ))}
+        &lt;/ul&gt;
+      &lt;/section&gt;
+
+      &lt;section className=&quot;featured&quot;&gt;
+        &lt;h2&gt;Featured Content&lt;/h2&gt;
+        &lt;div&gt;{featuredContent.html}&lt;/div&gt;
+      &lt;/section&gt;
+    &lt;/div&gt;
+  );
+}
+
+Static path generation:
+// app/products/[id]/page.tsx
+export async function generateStaticParams() {
+  const products = await fetch('https://api.example.com/products').then(r =&gt; r.json());
+
+  return products.map((product) =&gt; ({
+    id: product.id.toString(),
+  }));
+}
+
+export default async function Product({ params }) {
+  const product = await fetch(`https://api.example.com/products/${params.id}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;{product.name}&lt;/h1&gt;
+      &lt;p&gt;${product.price.toFixed(2)}&lt;/p&gt;
+      &lt;p&gt;{product.description}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}
+
+2. Dynamic Rendering (Server Rendering Strategy)
+Dynamic Rendering generates HTML on the server for each request at request time. Unlike static rendering, the content is not pre-rendered or cached but freshly generated for each user. This kind of rendering works best for:
+Personalized content: User dashboards, account pages
+Real-time data: Stock prices, live sports scores
+Request-specific information: Pages that use cookies, headers, or search parameters
+Frequently changing data: Content that needs to be up-to-date on every request
+How Dynamic Rendering Affects Core Web Vitals
+Largest Contentful Paint (LCP): With dynamic rendering, the server needs to generate HTML for each request, and that can't be fully cached at the CDN level. It is still faster than client-side rendering as HTML is generated on the server.
+Interaction to Next Paint (INP): The performance is similar to static rendering once the page is loaded. However, it can become slower if the dynamic content includes many Client Components.
+Cumulative Layout Shift (CLS): Dynamic rendering can potentially introduce CLS if the data fetched at request time significantly alters the layout of the page compared to a static structure. However, if the layout is stable and the dynamic content size fits within predefined areas, the CLS can be managed effectively.
+Code Examples:
+Explicit dynamic rendering:
+// app/dashboard/page.tsx
+export const dynamic = 'force-dynamic'; // Force this route to be dynamically rendered
+
+export default async function Dashboard() {
+  // This will run on every request
+  const data = await fetch('https://api.example.com/dashboard-data').then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Dashboard&lt;/h1&gt;
+      &lt;p&gt;Last updated: {new Date().toLocaleString()}&lt;/p&gt;
+      {/* Dashboard content */}
+    &lt;/div&gt;
+  );
+}
+
+Simplicit dynamic rendering with cookies:
+// app/profile/page.tsx
+import { cookies } from 'next/headers';
+
+export default async function Profile() {
+  // Using cookies() automatically opts into dynamic rendering
+  const userId = cookies().get('userId')?.value;
+
+  const user = await fetch(`https://api.example.com/users/${userId}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Welcome, {user.name}&lt;/h1&gt;
+      &lt;p&gt;Email: {user.email}&lt;/p&gt;
+      {/* Profile content */}
+    &lt;/div&gt;
+  );
+}
+
+Dynamic routes:
+// app/blog/[slug]/page.tsx
+export default async function BlogPost({ params }) {
+  // It will run at request time for any slug not explicitly pre-rendered
+  const post = await fetch(`https://api.example.com/posts/${params.slug}`).then(r =&gt; r.json());
+
+  return (
+    &lt;article&gt;
+      &lt;h1&gt;{post.title}&lt;/h1&gt;
+      &lt;div&gt;{post.content}&lt;/div&gt;
+    &lt;/article&gt;
+  );
+}
+
+3. Streaming (Server Rendering Strategy)
+Streaming allows you to progressively render UI from the server. Instead of waiting for all the data to be ready before sending any HTML, the server sends chunks of HTML as they become available. This is implemented using React's Suspense boundary.
+React Suspense works by creating boundaries in your component tree that can &quot;suspend&quot; rendering while waiting for asynchronous operations. When a component inside a Suspense boundary throws a promise (which happens automatically with data fetching in React Server Components), React pauses rendering of that component and its children, renders the fallback UI specified in the Suspense component, continues rendering other parts of the page outside this boundary, and eventually resumes and replaces the fallback with the actual component once the promise resolves.
+When streaming, this mechanism allows the server to send the initial HTML with fallbacks for suspended components while continuing to process suspended components in the background. The server then streams additional HTML chunks as each suspended component resolves, including instructions for the browser to seamlessly replace fallbacks with final content. It works well for:
+Pages with mixed data requirements: Some fast, some slow data sources
+Improving perceived performance: Show users something quickly while slower parts load
+Complex dashboards: Different widgets have different loading times
+Handling slow APIs: Prevent slow third-party services from blocking the entire page
+How Streaming Affects Core Web Vitals
+Largest Contentful Paint (LCP): Streaming can improve the perceived LCP. By sending the initial HTML content quickly, including potentially the largest element, the browser can render it sooner. Even if other parts of the page are still loading, the user sees the main content faster.
+Interaction to Next Paint (INP): Streaming can contribute to a better INP. When used with React's &lt;Suspense /&gt;, interactive elements in the faster-loading parts of the page can become interactive earlier, even while other components are still being streamed in. This allows users to engage with the page sooner.
+Cumulative Layout Shift (CLS): Streaming can cause layout shifts as new content streams in. However, when implemented carefully, streaming should not negatively impact CLS. The initially streamed content should establish the main layout, and subsequent streamed chunks should ideally fit within this structure without causing significant reflows or layout shifts. Using placeholders and ensuring dimensions are known can help prevent CLS.
+Code Examples:
+Basic Streaming with Suspense:
+// app/dashboard/page.tsx
+import { Suspense } from 'react';
+import UserProfile from './components/UserProfile';
+import RecentActivity from './components/RecentActivity';
+import PopularPosts from './components/PopularPosts';
+
+export default function Dashboard() {
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      {/* This loads quickly */}
+      &lt;h1&gt;Dashboard&lt;/h1&gt;
+
+      {/* User profile loads first */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-profile&quot;&gt;Loading profile...&lt;/div&gt;}&gt;
+        &lt;UserProfile /&gt;
+      &lt;/Suspense&gt;
+
+      {/* Recent activity might take longer */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-activity&quot;&gt;Loading activity...&lt;/div&gt;}&gt;
+        &lt;RecentActivity /&gt;
+      &lt;/Suspense&gt;
+
+      {/* Popular posts might be the slowest */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-posts&quot;&gt;Loading popular posts...&lt;/div&gt;}&gt;
+        &lt;PopularPosts /&gt;
+      &lt;/Suspense&gt;
+    &lt;/div&gt;
+  );
+}
+
+Nested Suspense boundaries for more granular control:
+// app/complex-page/page.tsx
+import { Suspense } from 'react';
+
+export default function ComplexPage() {
+  return (
+    &lt;Suspense fallback={&lt;PageSkeleton /&gt;}&gt;
+      &lt;Header /&gt;
+
+      &lt;div className=&quot;content-grid&quot;&gt;
+        &lt;div className=&quot;main-content&quot;&gt;
+          &lt;Suspense fallback={&lt;MainContentSkeleton /&gt;}&gt;
+            &lt;MainContent /&gt;
+          &lt;/Suspense&gt;
+        &lt;/div&gt;
+
+        &lt;div className=&quot;sidebar&quot;&gt;
+          &lt;Suspense fallback={&lt;SidebarTopSkeleton /&gt;}&gt;
+            &lt;SidebarTopSection /&gt;
+          &lt;/Suspense&gt;
+
+          &lt;Suspense fallback={&lt;SidebarBottomSkeleton /&gt;}&gt;
+            &lt;SidebarBottomSection /&gt;
+          &lt;/Suspense&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+
+      &lt;Footer /&gt;
+    &lt;/Suspense&gt;
+  );
+}
+
+Using Next.js loading.js convention:
+// app/products/loading.tsx - This will automatically be used as a Suspense fallback
+export default function Loading() {
+  return (
+    &lt;div className=&quot;products-loading-skeleton&quot;&gt;
+      &lt;div className=&quot;header-skeleton&quot; /&gt;
+      &lt;div className=&quot;filters-skeleton&quot; /&gt;
+      &lt;div className=&quot;products-grid-skeleton&quot;&gt;
+        {Array.from({ length: 12 }).map((_, i) =&gt; (
+          &lt;div key={i} className=&quot;product-card-skeleton&quot; /&gt;
+        ))}
+      &lt;/div&gt;
+    &lt;/div&gt;
+  );
+}
+
+// app/products/page.tsx
+export default async function ProductsPage() {
+  // This component can take time to load
+  // Next.js will automatically wrap it in Suspense
+  // and use the loading.js as the fallback
+  const products = await fetchProducts();
+
+  return &lt;ProductsList products={products} />;
+}
+
+4. Client Components and Client-Side Rendering
+Client Components are defined using the React 'use client' directive. They are pre-rendered on the server but then hydrated on the client, enabling interactivity. This is different from pure client-side rendering (CSR), where rendering happens entirely in the browser. In the traditional sense of CSR (where the initial HTML is minimal, and all rendering happens in the browser), Next.js has moved away from this as a default approach but it can still be achievable by using dynamic imports and setting ssr: false.
+// app/csr-example/page.tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
+
+// Lazily load a component with no SSR
+const ClientOnlyComponent = dynamic(
+  () =&gt; import('../components/heavy-component'),
+  { ssr: false, loading: () =&gt; &lt;p&gt;Loading...&lt;/p&gt; }
+);
+
+export default function CSRPage() {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() =&gt; {
+    setIsClient(true);
+  }, []);
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Client-Side Rendered Page&lt;/h1&gt;
+      {isClient ? (
+        &lt;ClientOnlyComponent /&gt;
+      ) : (
+        &lt;p&gt;Loading client component...&lt;/p&gt;
+      )}
+    &lt;/div&gt;
+  );
+}
+
+Despite the shift toward server rendering, there are valid use cases for CSR:
+Private dashboards: Where SEO doesn't matter, and you want to reduce server load
+Heavy interactive applications: Like data visualization tools or complex editors
+Browser-only APIs: When you need access to browser-specific features like localStorage or WebGL
+Third-party integrations: Some third-party widgets or libraries that only work in the browser
+While these are valid use cases, using Client Components is generally preferable to pure CSR in Next.js. Client Components give you the best of both worlds: server-rendered HTML for the initial load (improving SEO and LCP) with client-side interactivity after hydration. Pure CSR should be reserved for specific scenarios where server rendering is impossible or counterproductive.
+Client components are good for:
+Interactive UI elements: Forms, dropdowns, modals, tabs
+State-dependent UI: Components that change based on client state
+Browser API access: Components that need localStorage, geolocation, etc.
+Event-driven interactions: Click handlers, form submissions, animations
+Real-time updates: Chat interfaces, live notifications
+How Client Components Affect Core Web Vitals
+Largest Contentful Paint (LCP): Initial HTML includes the server-rendered version of Client Components, so LCP is reasonably fast. Hydration can delay interactivity but doesn't necessarily affect LCP.
+Interaction to Next Paint (INP): For Client Components, hydration can cause input delay during page load, and when the page is hydrated, performance depends on the efficiency of event handlers. Also, complex state management can impact responsiveness.
+Cumulative Layout Shift (CLS): Client-side data fetching can cause layout shifts as new data arrives. Also, state changes might alter the layout unexpectedly. Using Client Components will require careful implementation to prevent shifts.
+Code Examples:
+Basic Client Component:
+// app/components/Counter.tsx
+'use client';
+
+import { useState } from 'react';
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    &lt;div&gt;
+      &lt;p&gt;Count: {count}&lt;/p&gt;
+      &lt;button onClick={() =&gt; setCount(count + 1)}&gt;Increment&lt;/button&gt;
+    &lt;/div&gt;
+  );
+}
+
+Client Component with server data:
+// app/products/page.tsx - Server Component
+import ProductFilter from '../components/ProductFilter';
+
+export default async function ProductsPage() {
+  // Fetch data on the server
+  const products = await fetch('https://api.example.com/products').then(r =&gt; r.json());
+
+  // Pass server data to Client Component as props
+  return &lt;ProductFilter initialProducts={products} />;
+}
+
+Hybrid Approaches and Composition Patterns
+In real-world applications, you'll often use a combination of rendering strategies to achieve the best performance. Next.js makes it easy to compose Server and Client Components together.
+Server Components with Islands of Interactivity
+One of the most effective patterns is to use Server Components for the majority of your UI and add Client Components only where interactivity is needed. This approach:
+Minimizes JavaScript sent to the client
+Provides excellent initial load performance
+Maintains good interactivity where needed
+// app/products/[id]/page.tsx - Server Component
+import AddToCartButton from '../../components/AddToCartButton';
+import ProductReviews from '../../components/ProductReviews';
+import RelatedProducts from '../../components/RelatedProducts';
+
+export default async function ProductPage({ params }: {
+  params: { id: string; }
+}) {
+  // Fetch product data on the server
+  const product = await fetch(`https://api.example.com/products/${params.id}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div className=&quot;product-page&quot;&gt;
+      &lt;div className=&quot;product-main&quot;&gt;
+        &lt;h1&gt;{product.name}&lt;/h1&gt;
+        &lt;p className=&quot;price&quot;&gt;${product.price.toFixed(2)}&lt;/p&gt;
+        &lt;div className=&quot;description&quot;&gt;{product.description}&lt;/div&gt;
+
+        {/* Client Component for interactivity */}
+        &lt;AddToCartButton product={product} /&gt;
+      &lt;/div&gt;
+
+      {/* Server Component for product reviews */}
+      &lt;ProductReviews productId={params.id} /&gt;
+
+      {/* Server Component for related products */}
+      &lt;RelatedProducts categoryId={product.categoryId} /&gt;
+    &lt;/div&gt;
+  );
+}
+
+Partial Prerendering (Next.js 15)
+Next.js 15 introduced Partial Prerendering, a new hybrid rendering strategy that combines static and dynamic content in a single route. This allows you to:
+Statically generate a shell of the page
+Stream in dynamic, personalized content
+Get the best of both static and dynamic rendering
+Note: At the time of this writing, Partial Prerendering is experimental and is not ready for production use. Read more
+// app/dashboard/page.tsx
+import { unstable_noStore as noStore } from 'next/cache';
+import StaticContent from './components/StaticContent';
+import DynamicContent from './components/DynamicContent';
+
+export default function Dashboard() {
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      {/* This part is statically generated */}
+      &lt;StaticContent /&gt;
+
+      {/* This part is dynamically rendered */}
+      &lt;DynamicPart /&gt;
+    &lt;/div&gt;
+  );
+}
+
+// This component and its children will be dynamically rendered
+function DynamicPart() {
+  // Opt out of caching for this part
+  noStore();
+
+  return &lt;DynamicContent />;
+}
+
+Measuring Core Web Vitals in Next.js
+Understanding the impact of your rendering strategy choices requires measuring Core Web Vitals in real-world conditions. Here are some approaches:
+1. Vercel Analytics
+If you deploy on Vercel, you can use Vercel Analytics to automatically track Core Web Vitals for your production site:
+// app/layout.tsx
+import { Analytics } from '@vercel/analytics/react';
+
+export default function RootLayout({ children }: {
+  children: React.ReactNode;
+}) {
+  return (
+    &lt;html lang=&quot;en&quot;&gt;
+      &lt;body&gt;
+        {children}
+        &lt;Analytics /&gt;
+      &lt;/body&gt;
+    &lt;/html&gt;
+  );
+}
+
+2. Web Vitals API
+You can manually track Core Web Vitals using the web-vitals library:
+// app/components/WebVitalsReporter.tsx
+'use client';
+
+import { useEffect } from 'react';
+import { onCLS, onINP, onLCP } from 'web-vitals';
+
+export function WebVitalsReporter() {
+  useEffect(() =&gt; {
+    // Report Core Web Vitals
+    onCLS(metric =&gt; console.log('CLS:', metric.value));
+    onINP(metric =&gt; console.log('INP:', metric.value));
+    onLCP(metric =&gt; console.log('LCP:', metric.value));
+
+    // In a real app, you would send these to your analytics service
+  }, []);
+
+  return null; // This component doesn't render anything
+}
+
+3. Lighthouse and PageSpeed Insights
+For development and testing, use:
+Chrome DevTools Lighthouse tab
+PageSpeed Insights
+Chrome User Experience Report
+Making Practical Decisions: Which Rendering Strategy to Choose?
+Choosing the right rendering strategy depends on your specific requirements. Here's a decision framework:
+Choose Static Rendering when
+Content is the same for all users
+Data can be determined at build time
+Page doesn't need frequent updates
+SEO is critical
+You want the best possible performance
+Choose Dynamic Rendering when
+Content is personalized for each user
+Data must be fresh on every request
+You need access to request-time information
+Content changes frequently
+Choose Streaming when
+Page has a mix of fast and slow data requirements
+You want to improve perceived performance
+Some parts of the page depend on slow APIs
+You want to prioritize showing critical UI first
+Choose Client Components when
+UI needs to be interactive
+Component relies on browser APIs
+UI changes frequently based on user input
+You need real-time updates
+Conclusion
+Next.js provides a powerful set of rendering strategies that allow you to optimize for both performance and user experience. By understanding how each strategy affects Core Web Vitals, you can make informed decisions about how to build your application.
+Remember that the best approach is often a hybrid one, combining different rendering strategies based on the specific requirements of each part of your application. Start with Server Components as your default, use Static Rendering where possible, and add Client Components only where interactivity is needed.
+By following these principles and measuring your Core Web Vitals, you can create Next.js applications that are fast, responsive, and provide an excellent user experience.</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://www.thisdot.co/blog/next-js-rendering-strategies-and-how-they-affect-core-web-vitals</guid>
+      <itunes:author>This Dot Labs RSS feed</itunes:author>
+      <itunes:summary>When it comes to building fast and scalable web apps with Next.js, it’s important to understand how rendering works, especially with the App Router. Next.js organizes rendering around two main environments: the server and the client. On the server side, you’ll encounter three key strategies: Static Rendering, Dynamic Rendering, and Streaming. Each one comes with its own set of trade-offs and performance benefits, so knowing when to use which is crucial for delivering a great user experience.
+In this post, we'll break down each strategy, what it's good for, and how it impacts your site's performance, especially Core Web Vitals. We'll also explore hybrid approaches and provide practical guidance on choosing the right strategy for your use case.
+What Are Core Web Vitals?
+Core Web Vitals are a set of metrics defined by Google that measure real-world user experience on websites. These metrics play a major role in search engine rankings and directly affect how users perceive the speed and smoothness of your site.
+Largest Contentful Paint (LCP): This measures loading performance. It calculates the time taken for the largest visible content element to render. A good LCP is 2.5 seconds or less.
+Interaction to Next Paint (INP): This measures responsiveness to user input. A good INP is 200 milliseconds or less.
+Cumulative Layout Shift (CLS): This measures the visual stability of the page. It quantifies layout instability during load. A good CLS is 0.1 or less.
+If you want to dive deeper into Core Web Vitals and understand more about their impact on your website's performance, I recommend reading this detailed guide on  New Core Web Vitals and How They Work.
+Next.js Rendering Strategies and Core Web Vitals
+Let's explore each rendering strategy in detail:
+1. Static Rendering (Server Rendering Strategy)
+Static Rendering is the default for Server Components in Next.js. With this approach, components are rendered at build time (or during revalidation), and the resulting HTML is reused for each request. This pre-rendering happens on the server, not in the user's browser. Static rendering is ideal for routes where the data is not personalized to the user, and this makes it suitable for:
+Content-focused websites: Blogs, documentation, marketing pages
+E-commerce product listings: When product details don't change frequently
+SEO-critical pages: When search engine visibility is a priority
+High-traffic pages: When you want to minimize server load
+How Static Rendering Affects Core Web Vitals
+Largest Contentful Paint (LCP): Static rendering typically leads to excellent LCP scores (typically &lt; 1s). The Pre-rendered HTML can be cached and delivered instantly from CDNs, resulting in very fast delivery of the initial content, including the largest element. Also, there is no waiting for data fetching or rendering on the client.
+Interaction to Next Paint (INP): Static rendering provides a good foundation for INP, but doesn't guarantee optimal performance (typically ranges from 50-150 ms depending on implementation). While Server Components don't require hydration, any Client Components within the page still need JavaScript to become interactive. To achieve a very good INP score, you will need to make sure the Client Components within the page is minimal.
+Cumulative Layout Shift (CLS): While static rendering delivers the complete page structure upfront which can be very beneficial for CLS, achieving excellent CLS requires additional optimization strategies:
+Static HTML alone doesn't prevent layout shifts if resources load asynchronously
+Image dimensions must be properly specified to reserve space before the image loads
+Web fonts can cause text to reflow if not handled properly with font display strategies
+Dynamically injected content (ads, embeds, lazy-loaded elements) can disrupt layout stability
+CSS implementation significantly impacts CLS—immediate availability of styling information helps maintain visual stability
+Code Examples:
+Basic static rendering:
+// app/page.tsx (Server Component - Static Rendering by default)
+export default async function Page() {
+  const res = await fetch('https://api.example.com/static-data');
+  const data = await res.json();
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Static Content&lt;/h1&gt;
+      &lt;p&gt;{data.content}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}
+
+Static rendering with revalidation (ISR):
+// app/dashboard/page.tsx
+export default async function Dashboard() {
+  // Static data that revalidates every day
+  const siteStats = await fetch('https://api.example.com/site-stats', {
+    next: { revalidate: 86400 } // 24 hours
+  }).then(r =&gt; r.json());
+
+  // Data that revalidates every hour
+  const popularProducts = await fetch('https://api.example.com/popular-products', {
+    next: { revalidate: 3600 } // 1 hour
+  }).then(r =&gt; r.json());
+
+  // Data with a cache tag for on-demand revalidation
+  const featuredContent = await fetch('https://api.example.com/featured-content', {
+    next: { tags: ['featured'] }
+  }).then(r =&gt; r.json());
+
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      &lt;section className=&quot;stats&quot;&gt;
+        &lt;h2&gt;Site Statistics&lt;/h2&gt;
+        &lt;p&gt;Total Users: {siteStats.totalUsers}&lt;/p&gt;
+        &lt;p&gt;Total Orders: {siteStats.totalOrders}&lt;/p&gt;
+      &lt;/section&gt;
+
+      &lt;section className=&quot;popular&quot;&gt;
+        &lt;h2&gt;Popular Products&lt;/h2&gt;
+        &lt;ul&gt;
+          {popularProducts.map(product =&gt; (
+            &lt;li key={product.id}&gt;{product.name} - {product.sales} sold&lt;/li&gt;
+          ))}
+        &lt;/ul&gt;
+      &lt;/section&gt;
+
+      &lt;section className=&quot;featured&quot;&gt;
+        &lt;h2&gt;Featured Content&lt;/h2&gt;
+        &lt;div&gt;{featuredContent.html}&lt;/div&gt;
+      &lt;/section&gt;
+    &lt;/div&gt;
+  );
+}
+
+Static path generation:
+// app/products/[id]/page.tsx
+export async function generateStaticParams() {
+  const products = await fetch('https://api.example.com/products').then(r =&gt; r.json());
+
+  return products.map((product) =&gt; ({
+    id: product.id.toString(),
+  }));
+}
+
+export default async function Product({ params }) {
+  const product = await fetch(`https://api.example.com/products/${params.id}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;{product.name}&lt;/h1&gt;
+      &lt;p&gt;${product.price.toFixed(2)}&lt;/p&gt;
+      &lt;p&gt;{product.description}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}
+
+2. Dynamic Rendering (Server Rendering Strategy)
+Dynamic Rendering generates HTML on the server for each request at request time. Unlike static rendering, the content is not pre-rendered or cached but freshly generated for each user. This kind of rendering works best for:
+Personalized content: User dashboards, account pages
+Real-time data: Stock prices, live sports scores
+Request-specific information: Pages that use cookies, headers, or search parameters
+Frequently changing data: Content that needs to be up-to-date on every request
+How Dynamic Rendering Affects Core Web Vitals
+Largest Contentful Paint (LCP): With dynamic rendering, the server needs to generate HTML for each request, and that can't be fully cached at the CDN level. It is still faster than client-side rendering as HTML is generated on the server.
+Interaction to Next Paint (INP): The performance is similar to static rendering once the page is loaded. However, it can become slower if the dynamic content includes many Client Components.
+Cumulative Layout Shift (CLS): Dynamic rendering can potentially introduce CLS if the data fetched at request time significantly alters the layout of the page compared to a static structure. However, if the layout is stable and the dynamic content size fits within predefined areas, the CLS can be managed effectively.
+Code Examples:
+Explicit dynamic rendering:
+// app/dashboard/page.tsx
+export const dynamic = 'force-dynamic'; // Force this route to be dynamically rendered
+
+export default async function Dashboard() {
+  // This will run on every request
+  const data = await fetch('https://api.example.com/dashboard-data').then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Dashboard&lt;/h1&gt;
+      &lt;p&gt;Last updated: {new Date().toLocaleString()}&lt;/p&gt;
+      {/* Dashboard content */}
+    &lt;/div&gt;
+  );
+}
+
+Simplicit dynamic rendering with cookies:
+// app/profile/page.tsx
+import { cookies } from 'next/headers';
+
+export default async function Profile() {
+  // Using cookies() automatically opts into dynamic rendering
+  const userId = cookies().get('userId')?.value;
+
+  const user = await fetch(`https://api.example.com/users/${userId}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Welcome, {user.name}&lt;/h1&gt;
+      &lt;p&gt;Email: {user.email}&lt;/p&gt;
+      {/* Profile content */}
+    &lt;/div&gt;
+  );
+}
+
+Dynamic routes:
+// app/blog/[slug]/page.tsx
+export default async function BlogPost({ params }) {
+  // It will run at request time for any slug not explicitly pre-rendered
+  const post = await fetch(`https://api.example.com/posts/${params.slug}`).then(r =&gt; r.json());
+
+  return (
+    &lt;article&gt;
+      &lt;h1&gt;{post.title}&lt;/h1&gt;
+      &lt;div&gt;{post.content}&lt;/div&gt;
+    &lt;/article&gt;
+  );
+}
+
+3. Streaming (Server Rendering Strategy)
+Streaming allows you to progressively render UI from the server. Instead of waiting for all the data to be ready before sending any HTML, the server sends chunks of HTML as they become available. This is implemented using React's Suspense boundary.
+React Suspense works by creating boundaries in your component tree that can &quot;suspend&quot; rendering while waiting for asynchronous operations. When a component inside a Suspense boundary throws a promise (which happens automatically with data fetching in React Server Components), React pauses rendering of that component and its children, renders the fallback UI specified in the Suspense component, continues rendering other parts of the page outside this boundary, and eventually resumes and replaces the fallback with the actual component once the promise resolves.
+When streaming, this mechanism allows the server to send the initial HTML with fallbacks for suspended components while continuing to process suspended components in the background. The server then streams additional HTML chunks as each suspended component resolves, including instructions for the browser to seamlessly replace fallbacks with final content. It works well for:
+Pages with mixed data requirements: Some fast, some slow data sources
+Improving perceived performance: Show users something quickly while slower parts load
+Complex dashboards: Different widgets have different loading times
+Handling slow APIs: Prevent slow third-party services from blocking the entire page
+How Streaming Affects Core Web Vitals
+Largest Contentful Paint (LCP): Streaming can improve the perceived LCP. By sending the initial HTML content quickly, including potentially the largest element, the browser can render it sooner. Even if other parts of the page are still loading, the user sees the main content faster.
+Interaction to Next Paint (INP): Streaming can contribute to a better INP. When used with React's &lt;Suspense /&gt;, interactive elements in the faster-loading parts of the page can become interactive earlier, even while other components are still being streamed in. This allows users to engage with the page sooner.
+Cumulative Layout Shift (CLS): Streaming can cause layout shifts as new content streams in. However, when implemented carefully, streaming should not negatively impact CLS. The initially streamed content should establish the main layout, and subsequent streamed chunks should ideally fit within this structure without causing significant reflows or layout shifts. Using placeholders and ensuring dimensions are known can help prevent CLS.
+Code Examples:
+Basic Streaming with Suspense:
+// app/dashboard/page.tsx
+import { Suspense } from 'react';
+import UserProfile from './components/UserProfile';
+import RecentActivity from './components/RecentActivity';
+import PopularPosts from './components/PopularPosts';
+
+export default function Dashboard() {
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      {/* This loads quickly */}
+      &lt;h1&gt;Dashboard&lt;/h1&gt;
+
+      {/* User profile loads first */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-profile&quot;&gt;Loading profile...&lt;/div&gt;}&gt;
+        &lt;UserProfile /&gt;
+      &lt;/Suspense&gt;
+
+      {/* Recent activity might take longer */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-activity&quot;&gt;Loading activity...&lt;/div&gt;}&gt;
+        &lt;RecentActivity /&gt;
+      &lt;/Suspense&gt;
+
+      {/* Popular posts might be the slowest */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-posts&quot;&gt;Loading popular posts...&lt;/div&gt;}&gt;
+        &lt;PopularPosts /&gt;
+      &lt;/Suspense&gt;
+    &lt;/div&gt;
+  );
+}
+
+Nested Suspense boundaries for more granular control:
+// app/complex-page/page.tsx
+import { Suspense } from 'react';
+
+export default function ComplexPage() {
+  return (
+    &lt;Suspense fallback={&lt;PageSkeleton /&gt;}&gt;
+      &lt;Header /&gt;
+
+      &lt;div className=&quot;content-grid&quot;&gt;
+        &lt;div className=&quot;main-content&quot;&gt;
+          &lt;Suspense fallback={&lt;MainContentSkeleton /&gt;}&gt;
+            &lt;MainContent /&gt;
+          &lt;/Suspense&gt;
+        &lt;/div&gt;
+
+        &lt;div className=&quot;sidebar&quot;&gt;
+          &lt;Suspense fallback={&lt;SidebarTopSkeleton /&gt;}&gt;
+            &lt;SidebarTopSection /&gt;
+          &lt;/Suspense&gt;
+
+          &lt;Suspense fallback={&lt;SidebarBottomSkeleton /&gt;}&gt;
+            &lt;SidebarBottomSection /&gt;
+          &lt;/Suspense&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+
+      &lt;Footer /&gt;
+    &lt;/Suspense&gt;
+  );
+}
+
+Using Next.js loading.js convention:
+// app/products/loading.tsx - This will automatically be used as a Suspense fallback
+export default function Loading() {
+  return (
+    &lt;div className=&quot;products-loading-skeleton&quot;&gt;
+      &lt;div className=&quot;header-skeleton&quot; /&gt;
+      &lt;div className=&quot;filters-skeleton&quot; /&gt;
+      &lt;div className=&quot;products-grid-skeleton&quot;&gt;
+        {Array.from({ length: 12 }).map((_, i) =&gt; (
+          &lt;div key={i} className=&quot;product-card-skeleton&quot; /&gt;
+        ))}
+      &lt;/div&gt;
+    &lt;/div&gt;
+  );
+}
+
+// app/products/page.tsx
+export default async function ProductsPage() {
+  // This component can take time to load
+  // Next.js will automatically wrap it in Suspense
+  // and use the loading.js as the fallback
+  const products = await fetchProducts();
+
+  return &lt;ProductsList products={products} />;
+}
+
+4. Client Components and Client-Side Rendering
+Client Components are defined using the React 'use client' directive. They are pre-rendered on the server but then hydrated on the client, enabling interactivity. This is different from pure client-side rendering (CSR), where rendering happens entirely in the browser. In the traditional sense of CSR (where the initial HTML is minimal, and all rendering happens in the browser), Next.js has moved away from this as a default approach but it can still be achievable by using dynamic imports and setting ssr: false.
+// app/csr-example/page.tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
+
+// Lazily load a component with no SSR
+const ClientOnlyComponent = dynamic(
+  () =&gt; import('../components/heavy-component'),
+  { ssr: false, loading: () =&gt; &lt;p&gt;Loading...&lt;/p&gt; }
+);
+
+export default function CSRPage() {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() =&gt; {
+    setIsClient(true);
+  }, []);
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Client-Side Rendered Page&lt;/h1&gt;
+      {isClient ? (
+        &lt;ClientOnlyComponent /&gt;
+      ) : (
+        &lt;p&gt;Loading client component...&lt;/p&gt;
+      )}
+    &lt;/div&gt;
+  );
+}
+
+Despite the shift toward server rendering, there are valid use cases for CSR:
+Private dashboards: Where SEO doesn't matter, and you want to reduce server load
+Heavy interactive applications: Like data visualization tools or complex editors
+Browser-only APIs: When you need access to browser-specific features like localStorage or WebGL
+Third-party integrations: Some third-party widgets or libraries that only work in the browser
+While these are valid use cases, using Client Components is generally preferable to pure CSR in Next.js. Client Components give you the best of both worlds: server-rendered HTML for the initial load (improving SEO and LCP) with client-side interactivity after hydration. Pure CSR should be reserved for specific scenarios where server rendering is impossible or counterproductive.
+Client components are good for:
+Interactive UI elements: Forms, dropdowns, modals, tabs
+State-dependent UI: Components that change based on client state
+Browser API access: Components that need localStorage, geolocation, etc.
+Event-driven interactions: Click handlers, form submissions, animations
+Real-time updates: Chat interfaces, live notifications
+How Client Components Affect Core Web Vitals
+Largest Contentful Paint (LCP): Initial HTML includes the server-rendered version of Client Components, so LCP is reasonably fast. Hydration can delay interactivity but doesn't necessarily affect LCP.
+Interaction to Next Paint (INP): For Client Components, hydration can cause input delay during page load, and when the page is hydrated, performance depends on the efficiency of event handlers. Also, complex state management can impact responsiveness.
+Cumulative Layout Shift (CLS): Client-side data fetching can cause layout shifts as new data arrives. Also, state changes might alter the layout unexpectedly. Using Client Components will require careful implementation to prevent shifts.
+Code Examples:
+Basic Client Component:
+// app/components/Counter.tsx
+'use client';
+
+import { useState } from 'react';
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    &lt;div&gt;
+      &lt;p&gt;Count: {count}&lt;/p&gt;
+      &lt;button onClick={() =&gt; setCount(count + 1)}&gt;Increment&lt;/button&gt;
+    &lt;/div&gt;
+  );
+}
+
+Client Component with server data:
+// app/products/page.tsx - Server Component
+import ProductFilter from '../components/ProductFilter';
+
+export default async function ProductsPage() {
+  // Fetch data on the server
+  const products = await fetch('https://api.example.com/products').then(r =&gt; r.json());
+
+  // Pass server data to Client Component as props
+  return &lt;ProductFilter initialProducts={products} />;
+}
+
+Hybrid Approaches and Composition Patterns
+In real-world applications, you'll often use a combination of rendering strategies to achieve the best performance. Next.js makes it easy to compose Server and Client Components together.
+Server Components with Islands of Interactivity
+One of the most effective patterns is to use Server Components for the majority of your UI and add Client Components only where interactivity is needed. This approach:
+Minimizes JavaScript sent to the client
+Provides excellent initial load performance
+Maintains good interactivity where needed
+// app/products/[id]/page.tsx - Server Component
+import AddToCartButton from '../../components/AddToCartButton';
+import ProductReviews from '../../components/ProductReviews';
+import RelatedProducts from '../../components/RelatedProducts';
+
+export default async function ProductPage({ params }: {
+  params: { id: string; }
+}) {
+  // Fetch product data on the server
+  const product = await fetch(`https://api.example.com/products/${params.id}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div className=&quot;product-page&quot;&gt;
+      &lt;div className=&quot;product-main&quot;&gt;
+        &lt;h1&gt;{product.name}&lt;/h1&gt;
+        &lt;p className=&quot;price&quot;&gt;${product.price.toFixed(2)}&lt;/p&gt;
+        &lt;div className=&quot;description&quot;&gt;{product.description}&lt;/div&gt;
+
+        {/* Client Component for interactivity */}
+        &lt;AddToCartButton product={product} /&gt;
+      &lt;/div&gt;
+
+      {/* Server Component for product reviews */}
+      &lt;ProductReviews productId={params.id} /&gt;
+
+      {/* Server Component for related products */}
+      &lt;RelatedProducts categoryId={product.categoryId} /&gt;
+    &lt;/div&gt;
+  );
+}
+
+Partial Prerendering (Next.js 15)
+Next.js 15 introduced Partial Prerendering, a new hybrid rendering strategy that combines static and dynamic content in a single route. This allows you to:
+Statically generate a shell of the page
+Stream in dynamic, personalized content
+Get the best of both static and dynamic rendering
+Note: At the time of this writing, Partial Prerendering is experimental and is not ready for production use. Read more
+// app/dashboard/page.tsx
+import { unstable_noStore as noStore } from 'next/cache';
+import StaticContent from './components/StaticContent';
+import DynamicContent from './components/DynamicContent';
+
+export default function Dashboard() {
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      {/* This part is statically generated */}
+      &lt;StaticContent /&gt;
+
+      {/* This part is dynamically rendered */}
+      &lt;DynamicPart /&gt;
+    &lt;/div&gt;
+  );
+}
+
+// This component and its children will be dynamically rendered
+function DynamicPart() {
+  // Opt out of caching for this part
+  noStore();
+
+  return &lt;DynamicContent />;
+}
+
+Measuring Core Web Vitals in Next.js
+Understanding the impact of your rendering strategy choices requires measuring Core Web Vitals in real-world conditions. Here are some approaches:
+1. Vercel Analytics
+If you deploy on Vercel, you can use Vercel Analytics to automatically track Core Web Vitals for your production site:
+// app/layout.tsx
+import { Analytics } from '@vercel/analytics/react';
+
+export default function RootLayout({ children }: {
+  children: React.ReactNode;
+}) {
+  return (
+    &lt;html lang=&quot;en&quot;&gt;
+      &lt;body&gt;
+        {children}
+        &lt;Analytics /&gt;
+      &lt;/body&gt;
+    &lt;/html&gt;
+  );
+}
+
+2. Web Vitals API
+You can manually track Core Web Vitals using the web-vitals library:
+// app/components/WebVitalsReporter.tsx
+'use client';
+
+import { useEffect } from 'react';
+import { onCLS, onINP, onLCP } from 'web-vitals';
+
+export function WebVitalsReporter() {
+  useEffect(() =&gt; {
+    // Report Core Web Vitals
+    onCLS(metric =&gt; console.log('CLS:', metric.value));
+    onINP(metric =&gt; console.log('INP:', metric.value));
+    onLCP(metric =&gt; console.log('LCP:', metric.value));
+
+    // In a real app, you would send these to your analytics service
+  }, []);
+
+  return null; // This component doesn't render anything
+}
+
+3. Lighthouse and PageSpeed Insights
+For development and testing, use:
+Chrome DevTools Lighthouse tab
+PageSpeed Insights
+Chrome User Experience Report
+Making Practical Decisions: Which Rendering Strategy to Choose?
+Choosing the right rendering strategy depends on your specific requirements. Here's a decision framework:
+Choose Static Rendering when
+Content is the same for all users
+Data can be determined at build time
+Page doesn't need frequent updates
+SEO is critical
+You want the best possible performance
+Choose Dynamic Rendering when
+Content is personalized for each user
+Data must be fresh on every request
+You need access to request-time information
+Content changes frequently
+Choose Streaming when
+Page has a mix of fast and slow data requirements
+You want to improve perceived performance
+Some parts of the page depend on slow APIs
+You want to prioritize showing critical UI first
+Choose Client Components when
+UI needs to be interactive
+Component relies on browser APIs
+UI changes frequently based on user input
+You need real-time updates
+Conclusion
+Next.js provides a powerful set of rendering strategies that allow you to optimize for both performance and user experience. By understanding how each strategy affects Core Web Vitals, you can make informed decisions about how to build your application.
+Remember that the best approach is often a hybrid one, combining different rendering strategies based on the specific requirements of each part of your application. Start with Server Components as your default, use Static Rendering where possible, and add Client Components only where interactivity is needed.
+By following these principles and measuring your Core Web Vitals, you can create Next.js applications that are fast, responsive, and provide an excellent user experience.</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>666: What Are the Evils of the Web Platform?</title>
+      <link>https://shoptalkshow.com/666/</link>
+      <description>Show Description
+How it all comes back to the why column, dark patterns, privacy and tracking, getting emails forever from one purchase, how to be bold with communication while still being respectful, HTMHell, CSS mistakes, are we anti-JSON, and the state of FitVid in 2025.
+Listen on Website →
+Links
+
+Markup from hell - HTMHell
+Incomplete List of Mistakes in the Design of CSS [CSS Working Group Wiki]
+JSON Editing
+Douglas Crockford on JSON
+Fluid Video Plugin
+Sponsors</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://shoptalkshow.com/666/</guid>
+      <enclosure url="https://shoptalkshow.com/podcast-download/8228/666.mp3?nocache" type="audio/mpeg" length="0"/>
+      <itunes:author>ShopTalk</itunes:author>
+      <itunes:summary>Show Description
+How it all comes back to the why column, dark patterns, privacy and tracking, getting emails forever from one purchase, how to be bold with communication while still being respectful, HTMHell, CSS mistakes, are we anti-JSON, and the state of FitVid in 2025.
+Listen on Website →
+Links
+
+Markup from hell - HTMHell
+Incomplete List of Mistakes in the Design of CSS [CSS Working Group Wiki]
+JSON Editing
+Douglas Crockford on JSON
+Fluid Video Plugin
+Sponsors</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Episode 462: Supporting laid-off employee and how to rebuild culture after layoffs</title>
+      <link>https://softskills.audio/2025/05/26/episode-462-supporting-laid-off-employee-and-how-to-rebuild-culture-after-layoffs/</link>
+      <description>In this episode, Dave and Jamison answer these questions:
+One of my employees is probably getting laid off, what do I do!?!
+I’m a tech lead / manager for a consultancy and a contract reduction means that one of the people I supervise is likely going to get laid off soon! We’ve found new roles for most of my people, but it’s likely that at least one will get laid off.
+I want to help this person out. How much support is typical for a manager / ex-manager to provide in a job search, and how can I go above and beyond without doing too much?
+Over the last year, my company has gone through 3 rounds of layoff. The engineering culture has changed dramatically. With the fraction of engineers remaining, I am increasingly concerned that it’s going to be me next. The company’s posture is that everything is “business as usual” and there is nothing to be worried about, but this is what has been said all along. Morale seems to be low with low engagement in department initiatives.
+I am looking for some advice here, if I stay with the company – what is a healthy way to engage with the current culture to build it back up (or evolve it into something new)? If I decide to leave the company – how can I set proper boundaries to prepare for leaving, but remain engaged until a new opportunity arises?</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://softskills.audio/2025/05/26/episode-462-supporting-laid-off-employee-and-how-to-rebuild-culture-after-layoffs/</guid>
+      <enclosure url="https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-462.mp3?source=rss" type="audio/mpeg" length="0"/>
+      <itunes:author>Soft Skills Engineering</itunes:author>
+      <itunes:summary>In this episode, Dave and Jamison answer these questions:
+One of my employees is probably getting laid off, what do I do!?!
+I’m a tech lead / manager for a consultancy and a contract reduction means that one of the people I supervise is likely going to get laid off soon! We’ve found new roles for most of my people, but it’s likely that at least one will get laid off.
+I want to help this person out. How much support is typical for a manager / ex-manager to provide in a job search, and how can I go above and beyond without doing too much?
+Over the last year, my company has gone through 3 rounds of layoff. The engineering culture has changed dramatically. With the fraction of engineers remaining, I am increasingly concerned that it’s going to be me next. The company’s posture is that everything is “business as usual” and there is nothing to be worried about, but this is what has been said all along. Morale seems to be low with low engagement in department initiatives.
+I am looking for some advice here, if I stay with the company – what is a healthy way to engage with the current culture to build it back up (or evolve it into something new)? If I decide to leave the company – how can I set proper boundaries to prepare for leaving, but remain engaged until a new opportunity arises?</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>VS Code Open Sources GitHub Copilot Chat</title>
+      <link>https://www.buzzsprout.com/2226499</link>
+      <description>This week both Google and Microsoft held conferences where they announced all the new, great AI breakthroughs, but there were a few other notable, web dev-focused pieces in between. VS Code announced it will be open sourcing the GitHub Copilot Chat extension, refactoring relevant components into its core codebase, as the next logical step “in making VS Code an open source AI editor.”
+Microsoft has floated a new idea called “NLWeb” to make it easier for websites to turn themselves into AI apps using an LLM model and their own data. While this sounds interesting, it’s very early days yet and is not ready for prime time.
+A blog post from Remix creator Ryan Florence leaked earlier this week, and in it, Ryan shares that Remix v3 will move away from using React. The usual criticisms of React are present, and so Remix v3 will be completely new with a focus on a framework that’s AI friendly and leveraging all the Web APIs available today. 
+News:
+
+VS Code is open sourcing its AI chat extension
+Remix’s “Declaration of Independence” blog leaked
+And Microsoft introduces yet another AI standard
+
+Lightning News:
+
+Satya Nadella and podcasts
+Introducing Claude 4 
+
+What Makes Us Happy this Week:
+
+Paige - Daredevil: Born Again TV series
+Jack -  Baseball team Portland Pickles’ Red Head Appreciation Night
+TJ - The Philadelphia Inquirer’s summer reading list
+
+Thanks as always to our sponsor, the Blue Collar Coder channel on YouTube. You can join us in our Discord channel, explore our website and reach us via email, or talk to us on X, Bluesky, or YouTube.
+
+Front-end Fire website
+Blue Collar Coder on YouTube
+Blue Collar Coder on Discord
+Reach out via email
+Tweet at us on X @front_end_fire
+Follow us on Bluesky @front-end-fire.com
+Subscribe to our YouTube channel @Front-EndFirePodcast</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://www.buzzsprout.com/2226499</guid>
+      <enclosure url="https://www.buzzsprout.com/2226499/episodes/17225284-vs-code-open-sources-github-copilot-chat.mp3" type="audio/mpeg" length="0"/>
+      <itunes:author>Front-End Fire</itunes:author>
+      <itunes:summary>This week both Google and Microsoft held conferences where they announced all the new, great AI breakthroughs, but there were a few other notable, web dev-focused pieces in between. VS Code announced it will be open sourcing the GitHub Copilot Chat extension, refactoring relevant components into its core codebase, as the next logical step “in making VS Code an open source AI editor.”
+Microsoft has floated a new idea called “NLWeb” to make it easier for websites to turn themselves into AI apps using an LLM model and their own data. While this sounds interesting, it’s very early days yet and is not ready for prime time.
+A blog post from Remix creator Ryan Florence leaked earlier this week, and in it, Ryan shares that Remix v3 will move away from using React. The usual criticisms of React are present, and so Remix v3 will be completely new with a focus on a framework that’s AI friendly and leveraging all the Web APIs available today. 
+News:
+
+VS Code is open sourcing its AI chat extension
+Remix’s “Declaration of Independence” blog leaked
+And Microsoft introduces yet another AI standard
+
+Lightning News:
+
+Satya Nadella and podcasts
+Introducing Claude 4 
+
+What Makes Us Happy this Week:
+
+Paige - Daredevil: Born Again TV series
+Jack -  Baseball team Portland Pickles’ Red Head Appreciation Night
+TJ - The Philadelphia Inquirer’s summer reading list
+
+Thanks as always to our sponsor, the Blue Collar Coder channel on YouTube. You can join us in our Discord channel, explore our website and reach us via email, or talk to us on X, Bluesky, or YouTube.
+
+Front-end Fire website
+Blue Collar Coder on YouTube
+Blue Collar Coder on Discord
+Reach out via email
+Tweet at us on X @front_end_fire
+Follow us on Bluesky @front-end-fire.com
+Subscribe to our YouTube channel @Front-EndFirePodcast</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Building a TikTok-Style App with React Native &amp; Expo: Interview w Skylight Social CTO, Reed Harmeyer</title>
+      <link>https://podcasters.spotify.com/pod/show/modern-web/episodes/Building-a-TikTok-Style-App-with-React-Native--Expo-Interview-w-Skylight-Social-CTO--Reed-Harmeyer-e33g1fu</link>
+      <description>In this episode of the Modern Web Podcast, Danny Thompson sits down with Reed Harmeyer, CTO of Skylight Social, and Brandon Mathis, React Native engineer at This Dot Labs. They unpack the technical and strategic decisions behind Skylight’s meteoric growth: why they built on the AT Protocol, how they tackled video discovery and scaling challenges, and how a fast-tracked in-app video editor gave them an edge.
+
+
+Keypoints from this episode:
+
+Skylight Social was built on the AT Protocol, allowing users to retain followers across platforms like Blue Sky and enabling creators to publish interoperable content in a decentralized social network.
+
+The team used React Native with Expo to achieve rapid development and cross-platform performance—launching a high-quality, TikTok-like video experience in just days.
+
+An in-app video editor was prioritized to reduce friction for creators, built using a native SDK wrapped with Expo Modules, enabling features like clip rearranging, overlays, voiceovers, and AI-generated captions.
+
+User behavior data—specifically watch time—drives content recommendations, not just likes or follows, helping Skylight offer a personalized experience while navigating scaling challenges from hypergrowth.
+
+
+
+Follow Reed Harmeyer on Social Media
+Bluesky: https://bsky.app/profile/reedharmeyer.bsky.social
+Linkedin: https://www.linkedin.com/in/reed-harmeyer/</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://podcasters.spotify.com/pod/show/modern-web/episodes/Building-a-TikTok-Style-App-with-React-Native--Expo-Interview-w-Skylight-Social-CTO--Reed-Harmeyer-e33g1fu</guid>
+      <enclosure url="https://anchor.fm/s/f9191780/podcast/play/103334846/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2025-4-28%2F401165513-44100-2-ec812e0f97d61.mp3" type="audio/mpeg" length="0"/>
+      <itunes:author>Modern Web</itunes:author>
+      <itunes:summary>In this episode of the Modern Web Podcast, Danny Thompson sits down with Reed Harmeyer, CTO of Skylight Social, and Brandon Mathis, React Native engineer at This Dot Labs. They unpack the technical and strategic decisions behind Skylight’s meteoric growth: why they built on the AT Protocol, how they tackled video discovery and scaling challenges, and how a fast-tracked in-app video editor gave them an edge.
+
+
+Keypoints from this episode:
+
+Skylight Social was built on the AT Protocol, allowing users to retain followers across platforms like Blue Sky and enabling creators to publish interoperable content in a decentralized social network.
+
+The team used React Native with Expo to achieve rapid development and cross-platform performance—launching a high-quality, TikTok-like video experience in just days.
+
+An in-app video editor was prioritized to reduce friction for creators, built using a native SDK wrapped with Expo Modules, enabling features like clip rearranging, overlays, voiceovers, and AI-generated captions.
+
+User behavior data—specifically watch time—drives content recommendations, not just likes or follows, helping Skylight offer a personalized experience while navigating scaling challenges from hypergrowth.
+
+
+
+Follow Reed Harmeyer on Social Media
+Bluesky: https://bsky.app/profile/reedharmeyer.bsky.social
+Linkedin: https://www.linkedin.com/in/reed-harmeyer/</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Greg Sadetsky, Antonie Leclair - Disco</title>
+      <link>https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Greg-Sadetsky--Antonie-Leclair---Disco-e33bjbd</link>
+      <description>This week we talk to Greg Sadetsky and Antoine Leclair, the creators of Disco. Disco make running you own infra a piece of cake.
+
+https://disco.cloud/
+https://docs.letsdisco.dev/
+https://github.com/letsdiscodev/
+https://github.com/gregsadetsky
+https://github.com/antoineleclair
+
+
+Episode sponsored By WorkOS (https://workos.com).
+Become a paid subscriber our patreon, spotify, or apple podcasts for the full episode.
+
+https://www.patreon.com/devtoolsfm
+https://podcasters.spotify.com/pod/show/devtoolsfm/subscribe
+https://podcasts.apple.com/us/podcast/devtools-fm/id1566647758
+https://www.youtube.com/@devtoolsfm/membership</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Greg-Sadetsky--Antonie-Leclair---Disco-e33bjbd</guid>
+      <enclosure url="https://anchor.fm/s/dd6922b4/podcast/play/103189293/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2025-4-25%2F400981004-44100-2-dad9bdc59c9aa.m4a" type="audio/mpeg" length="0"/>
+      <itunes:author>devtools.fm: Developer Tools, Open Source, Software Development</itunes:author>
+      <itunes:summary>This week we talk to Greg Sadetsky and Antoine Leclair, the creators of Disco. Disco make running you own infra a piece of cake.
+
+https://disco.cloud/
+https://docs.letsdisco.dev/
+https://github.com/letsdiscodev/
+https://github.com/gregsadetsky
+https://github.com/antoineleclair
+
+
+Episode sponsored By WorkOS (https://workos.com).
+Become a paid subscriber our patreon, spotify, or apple podcasts for the full episode.
+
+https://www.patreon.com/devtoolsfm
+https://podcasters.spotify.com/pod/show/devtoolsfm/subscribe
+https://podcasts.apple.com/us/podcast/devtools-fm/id1566647758
+https://www.youtube.com/@devtoolsfm/membership</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Relatively new things you should know about HTML with Chris Coyier (Repeat)</title>
+      <link>http://podrocket.logrocket.com/relatively-new-things-you-should-know-about-html-chris-coyier-repeat</link>
+      <description>In this repeat episode, Chris Coyier, co-founder of CodePen, talks about the evolving landscape of HTML heading into 2025. He delves into topics like the slow evolution of HTML compared to CSS and JavaScript, the importance of backwards compatibility, new HTML elements and pseudo-elements, and the potential of declarative shadow DOM for server-side rendering in web components.
+Links
+Website: https://chriscoyier.net
+Codepen: https://codepen.io/chriscoyier
+Frontend Social: https://front-end.social/@chriscoyier
+Github: https://github.com/chriscoyier
+Threads: https://www.threads.net/@chriscoyier
+Bluesky: https://bsky.app/profile/chriscoyier.net
+We want to hear from you!
+How did you find us? Did you see us on Twitter? In a newsletter? Or maybe we were recommended by a friend?
+Let us know by sending an email to our producer, Em, at emily.kochanek@logrocket.com (mailto:emily.kochanek@logrocket.com), or tweet at us at PodRocketPod (https://twitter.com/PodRocketpod).
+Follow us. Get free stickers.
+Follow us on Apple Podcasts, fill out this form (https://podrocket.logrocket.com/get-podrocket-stickers), and we’ll send you free PodRocket stickers!
+What does LogRocket do?
+LogRocket provides AI-first session replay and analytics that surfaces the UX and technical issues impacting user experiences. Start understanding where your users are struggling by trying it for free at LogRocket.com. Try LogRocket for free today. (https://logrocket.com/signup/?pdr) Special Guest: Chris Coyier.</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>http://podrocket.logrocket.com/relatively-new-things-you-should-know-about-html-chris-coyier-repeat</guid>
+      <enclosure url="https://chrt.fm/track/7F1212/aphid.fireside.fm/d/1437767933/3911462c-bca2-48c2-9103-610ba304c673/91d26313-24a6-4ffa-bef9-1f249a04342e.mp3" type="audio/mpeg" length="0"/>
+      <itunes:author>PodRocket - A web development podcast from LogRocket</itunes:author>
+      <itunes:summary>In this repeat episode, Chris Coyier, co-founder of CodePen, talks about the evolving landscape of HTML heading into 2025. He delves into topics like the slow evolution of HTML compared to CSS and JavaScript, the importance of backwards compatibility, new HTML elements and pseudo-elements, and the potential of declarative shadow DOM for server-side rendering in web components.
+Links
+Website: https://chriscoyier.net
+Codepen: https://codepen.io/chriscoyier
+Frontend Social: https://front-end.social/@chriscoyier
+Github: https://github.com/chriscoyier
+Threads: https://www.threads.net/@chriscoyier
+Bluesky: https://bsky.app/profile/chriscoyier.net
+We want to hear from you!
+How did you find us? Did you see us on Twitter? In a newsletter? Or maybe we were recommended by a friend?
+Let us know by sending an email to our producer, Em, at emily.kochanek@logrocket.com (mailto:emily.kochanek@logrocket.com), or tweet at us at PodRocketPod (https://twitter.com/PodRocketpod).
+Follow us. Get free stickers.
+Follow us on Apple Podcasts, fill out this form (https://podrocket.logrocket.com/get-podrocket-stickers), and we’ll send you free PodRocket stickers!
+What does LogRocket do?
+LogRocket provides AI-first session replay and analytics that surfaces the UX and technical issues impacting user experiences. Start understanding where your users are struggling by trying it for free at LogRocket.com. Try LogRocket for free today. (https://logrocket.com/signup/?pdr) Special Guest: Chris Coyier.</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>TypeScript, Security, and Type Juggling with Ariel Shulman &amp; Liran Tal - JSJ 679</title>
+      <link>https://www.spreaker.com/episode/typescript-security-and-type-juggling-with-ariel-shulman-liran-tal-jsj-679--66327148</link>
+      <description>In this episode, we dove headfirst into the swirling waters of TypeScript, its real-world use cases, and where it starts to fall short—especially when it comes to security. Joining us from sunny Tel Aviv (and a slightly cooler Portland), we had the brilliant Ariel Shulman and security advocate Liran Tal bring the heat on everything from type safety to runtime vulnerabilities.
+
+We started off with a friendly debate: Has TypeScript really taken over the world? Our verdict? Pretty much. Whether it’s starter projects, enterprise codebases, or AI-generated snippets, TypeScript has become the de facto standard. But as we quickly found out, that doesn’t mean it’s perfect.
+
+Key Takeaways:
+-TypeScript ≠ Security
+We tend to trust TypeScript a bit too much. It’s a build-time tool, not a runtime enforcer. As Liran pointed out, “TypeScript is not a security tool,” and treating it like one leads to dangerous assumptions.
+-Type Juggling is Real (and Sneaky)
+We explored how something as innocent as using as string on request data can open the door to vulnerabilities like HTTP parameter pollution and prototype pollution. Just because your IDE is happy doesn’t mean your runtime is.
+-Enter Zod – Runtime Type Checking to the Rescue?
+Zod got some love for bridging the dev-time/runtime gap by validating data on the fly and inferring TypeScript types. But even Zod isn’t foolproof. For example, unless you're using .strict(), extra fields can sneak past your validations, leading to mass assignment bugs.
+-Common Developer Fallacies
+We discussed the misplaced confidence developers have in things like code coverage and TypeScript alone. One of the big takeaways: defense in depth matters. Just like testing, layering your security practices (like using Zod, type guards, and proper sanitization) is key.
+-TypeScript Best Practices Are Evolving
+From discriminated unions to avoiding any, from using Maps over plain objects to prevent prototype pollution—TypeScript developers are adapting. And tools like modern Node.js now support type stripping, which makes working with .ts files at runtime a bit easier.
+
+Become a supporter of this podcast: https://www.spreaker.com/podcast/javascript-jabber--6102064/support.</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://www.spreaker.com/episode/typescript-security-and-type-juggling-with-ariel-shulman-liran-tal-jsj-679--66327148</guid>
+      <enclosure url="https://dts.podtrac.com/redirect.mp3/api.spreaker.com/download/episode/66327148/jsj_679.mp3" type="audio/mpeg" length="0"/>
+      <itunes:author>JavaScript Jabber</itunes:author>
+      <itunes:summary>In this episode, we dove headfirst into the swirling waters of TypeScript, its real-world use cases, and where it starts to fall short—especially when it comes to security. Joining us from sunny Tel Aviv (and a slightly cooler Portland), we had the brilliant Ariel Shulman and security advocate Liran Tal bring the heat on everything from type safety to runtime vulnerabilities.
+
+We started off with a friendly debate: Has TypeScript really taken over the world? Our verdict? Pretty much. Whether it’s starter projects, enterprise codebases, or AI-generated snippets, TypeScript has become the de facto standard. But as we quickly found out, that doesn’t mean it’s perfect.
+
+Key Takeaways:
+-TypeScript ≠ Security
+We tend to trust TypeScript a bit too much. It’s a build-time tool, not a runtime enforcer. As Liran pointed out, “TypeScript is not a security tool,” and treating it like one leads to dangerous assumptions.
+-Type Juggling is Real (and Sneaky)
+We explored how something as innocent as using as string on request data can open the door to vulnerabilities like HTTP parameter pollution and prototype pollution. Just because your IDE is happy doesn’t mean your runtime is.
+-Enter Zod – Runtime Type Checking to the Rescue?
+Zod got some love for bridging the dev-time/runtime gap by validating data on the fly and inferring TypeScript types. But even Zod isn’t foolproof. For example, unless you're using .strict(), extra fields can sneak past your validations, leading to mass assignment bugs.
+-Common Developer Fallacies
+We discussed the misplaced confidence developers have in things like code coverage and TypeScript alone. One of the big takeaways: defense in depth matters. Just like testing, layering your security practices (like using Zod, type guards, and proper sanitization) is key.
+-TypeScript Best Practices Are Evolving
+From discriminated unions to avoiding any, from using Maps over plain objects to prevent prototype pollution—TypeScript developers are adapting. And tools like modern Node.js now support type stripping, which makes working with .ts files at runtime a bit easier.
+
+Become a supporter of this podcast: https://www.spreaker.com/podcast/javascript-jabber--6102064/support.</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>906: Tech Startups and Raising Money with Dan Levine (Vercel, Sentry, Mux…)</title>
+      <link>https://syntax.fm/906</link>
+      <description>Wes and Scott talk with VC Dan Levine about how developers can raise venture capital, what investors look for in early-stage startups, the realities of bootstrapping vs. fundraising, and why great ideas often start as simple side projects.
+ Show Notes
+  
+ 00:00 Welcome to Syntax!
+  00:55 Dan’s background and career
+  03:10 Is it common for tech investors to come from a tech background?
+  04:40 How can developers raise money?
+  08:35 What investors look for
+  12:39 How much funding is enough?
+  15:41 Are founders working with multiple investors?
+  18:26 What can you use the money for?
+  22:49 How much influence do investors have in the business?
+  29:56 Brought to you by Sentry.io
+  29:56 How involved are VCs in the business?
+  34:22 How do you know a startup is in trouble—and what can you do about it?
+  38:56 How much of the company do investors own?
+  40:43 What’s the endgame for investors?
+  44:02 How do acqui-hires work?
+  46:29 Is the AI space a real opportunity or just hype?
+  53:22 Sick Picks + Shameless Plugs
+  
+ Sick Picks
+  
+ Dan: 
+  Dandelion Chocolate
+  Jules Pizza
+  
+  
+ Shameless Plugs
+  
+ Dan: Linear
+  
+ Hit us up on Socials!
+  Syntax: X Instagram Tiktok LinkedIn Threads
+  Wes: X Instagram Tiktok LinkedIn Threads
+  Scott: X Instagram Tiktok LinkedIn Threads
+  Randy: X Instagram YouTube Threads</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://syntax.fm/906</guid>
+      <enclosure url="https://traffic.libsyn.com/secure/syntax/Syntax_-_906.mp3?dest-id=532671" type="audio/mpeg" length="0"/>
+      <itunes:author>Syntax - Tasty Web Development Treats</itunes:author>
+      <itunes:summary>Wes and Scott talk with VC Dan Levine about how developers can raise venture capital, what investors look for in early-stage startups, the realities of bootstrapping vs. fundraising, and why great ideas often start as simple side projects.
+ Show Notes
+  
+ 00:00 Welcome to Syntax!
+  00:55 Dan’s background and career
+  03:10 Is it common for tech investors to come from a tech background?
+  04:40 How can developers raise money?
+  08:35 What investors look for
+  12:39 How much funding is enough?
+  15:41 Are founders working with multiple investors?
+  18:26 What can you use the money for?
+  22:49 How much influence do investors have in the business?
+  29:56 Brought to you by Sentry.io
+  29:56 How involved are VCs in the business?
+  34:22 How do you know a startup is in trouble—and what can you do about it?
+  38:56 How much of the company do investors own?
+  40:43 What’s the endgame for investors?
+  44:02 How do acqui-hires work?
+  46:29 Is the AI space a real opportunity or just hype?
+  53:22 Sick Picks + Shameless Plugs
+  
+ Sick Picks
+  
+ Dan: 
+  Dandelion Chocolate
+  Jules Pizza
+  
+  
+ Shameless Plugs
+  
+ Dan: Linear
+  
+ Hit us up on Socials!
+  Syntax: X Instagram Tiktok LinkedIn Threads
+  Wes: X Instagram Tiktok LinkedIn Threads
+  Scott: X Instagram Tiktok LinkedIn Threads
+  Randy: X Instagram YouTube Threads</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>905: You Should Learn Nuxt!</title>
+      <link>https://syntax.fm/905</link>
+      <description>CJ steps in for Scott and joins Wes to share his experience working with Nuxt, from routing and data fetching to the pros and cons of the framework. They break down the Nuxt ecosystem, directory structure, and how it handles server routes and modules.
+ Show Notes
+  
+ 00:00 Syntax Meetup!
+  00:26 Welcome to Syntax
+  01:21 The deal with Nuxt. 
+  CJ’s Nuxt Course.
+  
+  02:51 Why do you like Vue?
+  04:52 Brought to you by Sentry.io.
+  05:17 Routing with Nuxt. 
+  h3 - The Web Framework for Modern JavaScript Era.
+  Nuxt Guides.
+  
+  06:12 Built on Nitro.
+  06:49 The Nuxt Ecosystem.
+  07:52 API Route Support.
+  08:15 Nuxt Directory Structure.
+  09:09 Does Nuxt do too much for you?
+  11:15 Data fetching in a Nuxt app.
+  13:25 RPC, Form Actions, Server Actions?
+  15:00 Nuxt Server Folder Hastle.
+  15:57 useFetch Hook. 
+  CJ’s Nuxt Crash Course.
+  
+  17:29 Core Modules and Community Modules? 
+  Nuxt Modules.
+  shadcn-nuxt.
+  @nuxt/ui.
+  DaisyUI.
+  Pinia.
+  
+  21:17 Nuxt Hosting. 
+  Deploy.
+  hub.nuxt.
+  
+  23:59 Anything you don’t like?
+  
+ Hit us up on Socials!
+  Syntax: X Instagram Tiktok LinkedIn Threads
+  Wes: X Instagram Tiktok LinkedIn Threads
+  Scott: X Instagram Tiktok LinkedIn Threads
+  Randy: X Instagram YouTube Threads</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://syntax.fm/905</guid>
+      <enclosure url="https://traffic.libsyn.com/secure/syntax/Syntax_-_905.mp3?dest-id=532671" type="audio/mpeg" length="0"/>
+      <itunes:author>Syntax - Tasty Web Development Treats</itunes:author>
+      <itunes:summary>CJ steps in for Scott and joins Wes to share his experience working with Nuxt, from routing and data fetching to the pros and cons of the framework. They break down the Nuxt ecosystem, directory structure, and how it handles server routes and modules.
+ Show Notes
+  
+ 00:00 Syntax Meetup!
+  00:26 Welcome to Syntax
+  01:21 The deal with Nuxt. 
+  CJ’s Nuxt Course.
+  
+  02:51 Why do you like Vue?
+  04:52 Brought to you by Sentry.io.
+  05:17 Routing with Nuxt. 
+  h3 - The Web Framework for Modern JavaScript Era.
+  Nuxt Guides.
+  
+  06:12 Built on Nitro.
+  06:49 The Nuxt Ecosystem.
+  07:52 API Route Support.
+  08:15 Nuxt Directory Structure.
+  09:09 Does Nuxt do too much for you?
+  11:15 Data fetching in a Nuxt app.
+  13:25 RPC, Form Actions, Server Actions?
+  15:00 Nuxt Server Folder Hastle.
+  15:57 useFetch Hook. 
+  CJ’s Nuxt Crash Course.
+  
+  17:29 Core Modules and Community Modules? 
+  Nuxt Modules.
+  shadcn-nuxt.
+  @nuxt/ui.
+  DaisyUI.
+  Pinia.
+  
+  21:17 Nuxt Hosting. 
+  Deploy.
+  hub.nuxt.
+  
+  23:59 Anything you don’t like?
+  
+ Hit us up on Socials!
+  Syntax: X Instagram Tiktok LinkedIn Threads
+  Wes: X Instagram Tiktok LinkedIn Threads
+  Scott: X Instagram Tiktok LinkedIn Threads
+  Randy: X Instagram YouTube Threads</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+  </channel>
+</rss>

--- a/rss.xml
+++ b/rss.xml
@@ -1,0 +1,1614 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <atom:link href="https://&lt;your-domain-here&gt;/rss.xml" rel="self" type="application/rss+xml"/>
+    <title>Weekly Podcast Updates</title>
+    <link>https://&lt;your-project-link-here&gt;</link>
+    <language>en-us</language>
+    <description>Weekly digest of podcast episodes from week 22, starting 2025-05-26.</description>
+    <lastBuildDate>Tue, 03 Jun 2025 14:51:05 GMT</lastBuildDate>
+    <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+    <item>
+      <title>The Myth of Perfect Code w/ Marc Backes</title>
+      <link>https://art19.com/shows/whiskey-web-and-whatnot</link>
+      <description>This week, Robbie and Chuck talk with Marc Backes about Vue vs. React, work-life balance, and the realities of messy codebases. They also sip an Evan Williams Single Barrel, debate inbox zero, and discuss Marc’s adventures in coffee roasting and pilot training.
+In this episode:
+
+(00:00) - Intro
+(01:45) - Whiskey review and rating: Evan Williams Single Barrel
+(09:03) - Hot Take: Inferred types vs explicit types
+(10:04) - Hot Take: Tailwind vs vanilla CSS
+(10:59) - Hot Take: Git Rebase vs Git Merge
+(11:27) - Nested ternaries?
+(15:58) - Real code vs ideal code
+(21:43) - Why work/life balance matters
+(30:28) - Why Marc chose Vue over React
+(31:19) - Ryan Reynolds speaking at Post/Con
+(32:40) - Render Atlanta and upcoming conferences
+(33:48) - Marc's connection to Mexico
+(34:54) - Discussing different foods
+(37:09) - Marc's inbox zero strategy
+(40:26) - Learning to fly
+(44:06) - Roasting coffee as a hobby
+(46:13) - Personal branding and standing out
+(51:19) - Plugs
+
+Links
+
+Evan Williams Single Barrel: https://evanwilliams.com/single-barrel
+Vue: https://vuejs.org/
+Nuxt: https://nuxt.com/
+Norlan: https://norlanglass.com/
+Nintendo: https://www.nintendo.com/
+Switch 2: https://www.nintendo.com/us/gaming-systems/switch-2/
+Double Double Oaked Woodford: https://www.woodfordreserve.com/whiskey/double-double-oaked/
+Typescript: https://www.typescriptlang.org/
+Tailwind CSS: https://tailwindcss.com/
+React: https://react.dev/
+jQuery: https://jquery.com/
+Ryan Reynolds: https://en.wikipedia.org/wiki/Ryan_Reynolds
+Post Con: https://postcon.postman.com/
+Aviation Gin: https://www.aviationgin.com/
+Mint Mobile: https://www.mintmobile.com/
+Render Conf: https://www.renderatl.com/
+Taco Bell: https://www.tacobell.com/
+Marc Backes - Achieving Inbox Zero: https://marc.dev/blog/inbox-zero
+Superhuman: https://superhuman.com/
+Vim: https://www.vim.org/
+Vue: https://vuejs.org/
+Vite: https://vite.dev/
+Terminal Coffee: https://www.terminal.shop/
+Dax: https://x.com/thdxr/
+Jack Daniel's: https://www.jackdaniels.com/
+Kelly Vaughn: https://x.com/kvlly
+
+Connect with Marc
+
+Website: https://marc.dev/
+X / Twitter: https://x.com/themarcba
+
+Connect with Chuck and Robbie
+
+Robbie Wagner: https://x.com/RobbieTheWagner
+Chuck Carpenter: https://x.com/CharlesWthe3rd
+
+Subscribe and stay in touch
+
+Website: https://whiskey.fm
+Apple Podcasts: https://podcasts.apple.com/us/podcast/whiskey-web-and-whatnot/id1552776603
+Spotify: https://open.spotify.com/show/19jiuHAqzeKnkleQUpZxDf
+Overcast: https://overcast.fm/itunes1552776603
+YouTube: https://www.youtube.com/@WhiskeyWebAndWhatnot
+
+Whiskey Web and Whatnot Merch
+Enjoying the podcast and want us to make more? Help support us by picking up some of our fresh merch at https://whiskey.fund.
+See Privacy Policy at https://art19.com/privacy and California Privacy Notice at https://art19.com/privacy#do-not-sell-my-info.</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://art19.com/shows/whiskey-web-and-whatnot</guid>
+      <enclosure url="https://rss.art19.com/episodes/44535030-2888-42a8-926c-d03a9a6aef2c.mp3?rss_browser=BAhJIg9yc3MtcGFyc2VyBjoGRVQ%3D--42d668516e215326a0c0e36404173d504b339a70" type="audio/mpeg" length="0"/>
+      <itunes:author>Whiskey Web and Whatnot: Web Development, Neat</itunes:author>
+      <itunes:summary>This week, Robbie and Chuck talk with Marc Backes about Vue vs. React, work-life balance, and the realities of messy codebases. They also sip an Evan Williams Single Barrel, debate inbox zero, and discuss Marc’s adventures in coffee roasting and pilot training.
+In this episode:
+
+(00:00) - Intro
+(01:45) - Whiskey review and rating: Evan Williams Single Barrel
+(09:03) - Hot Take: Inferred types vs explicit types
+(10:04) - Hot Take: Tailwind vs vanilla CSS
+(10:59) - Hot Take: Git Rebase vs Git Merge
+(11:27) - Nested ternaries?
+(15:58) - Real code vs ideal code
+(21:43) - Why work/life balance matters
+(30:28) - Why Marc chose Vue over React
+(31:19) - Ryan Reynolds speaking at Post/Con
+(32:40) - Render Atlanta and upcoming conferences
+(33:48) - Marc's connection to Mexico
+(34:54) - Discussing different foods
+(37:09) - Marc's inbox zero strategy
+(40:26) - Learning to fly
+(44:06) - Roasting coffee as a hobby
+(46:13) - Personal branding and standing out
+(51:19) - Plugs
+
+Links
+
+Evan Williams Single Barrel: https://evanwilliams.com/single-barrel
+Vue: https://vuejs.org/
+Nuxt: https://nuxt.com/
+Norlan: https://norlanglass.com/
+Nintendo: https://www.nintendo.com/
+Switch 2: https://www.nintendo.com/us/gaming-systems/switch-2/
+Double Double Oaked Woodford: https://www.woodfordreserve.com/whiskey/double-double-oaked/
+Typescript: https://www.typescriptlang.org/
+Tailwind CSS: https://tailwindcss.com/
+React: https://react.dev/
+jQuery: https://jquery.com/
+Ryan Reynolds: https://en.wikipedia.org/wiki/Ryan_Reynolds
+Post Con: https://postcon.postman.com/
+Aviation Gin: https://www.aviationgin.com/
+Mint Mobile: https://www.mintmobile.com/
+Render Conf: https://www.renderatl.com/
+Taco Bell: https://www.tacobell.com/
+Marc Backes - Achieving Inbox Zero: https://marc.dev/blog/inbox-zero
+Superhuman: https://superhuman.com/
+Vim: https://www.vim.org/
+Vue: https://vuejs.org/
+Vite: https://vite.dev/
+Terminal Coffee: https://www.terminal.shop/
+Dax: https://x.com/thdxr/
+Jack Daniel's: https://www.jackdaniels.com/
+Kelly Vaughn: https://x.com/kvlly
+
+Connect with Marc
+
+Website: https://marc.dev/
+X / Twitter: https://x.com/themarcba
+
+Connect with Chuck and Robbie
+
+Robbie Wagner: https://x.com/RobbieTheWagner
+Chuck Carpenter: https://x.com/CharlesWthe3rd
+
+Subscribe and stay in touch
+
+Website: https://whiskey.fm
+Apple Podcasts: https://podcasts.apple.com/us/podcast/whiskey-web-and-whatnot/id1552776603
+Spotify: https://open.spotify.com/show/19jiuHAqzeKnkleQUpZxDf
+Overcast: https://overcast.fm/itunes1552776603
+YouTube: https://www.youtube.com/@WhiskeyWebAndWhatnot
+
+Whiskey Web and Whatnot Merch
+Enjoying the podcast and want us to make more? Help support us by picking up some of our fresh merch at https://whiskey.fund.
+See Privacy Policy at https://art19.com/privacy and California Privacy Notice at https://art19.com/privacy#do-not-sell-my-info.</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Next.js Rendering Strategies and how they affect core web vitals</title>
+      <link>https://www.thisdot.co/blog/next-js-rendering-strategies-and-how-they-affect-core-web-vitals</link>
+      <description>When it comes to building fast and scalable web apps with Next.js, it’s important to understand how rendering works, especially with the App Router. Next.js organizes rendering around two main environments: the server and the client. On the server side, you’ll encounter three key strategies: Static Rendering, Dynamic Rendering, and Streaming. Each one comes with its own set of trade-offs and performance benefits, so knowing when to use which is crucial for delivering a great user experience.
+In this post, we'll break down each strategy, what it's good for, and how it impacts your site's performance, especially Core Web Vitals. We'll also explore hybrid approaches and provide practical guidance on choosing the right strategy for your use case.
+What Are Core Web Vitals?
+Core Web Vitals are a set of metrics defined by Google that measure real-world user experience on websites. These metrics play a major role in search engine rankings and directly affect how users perceive the speed and smoothness of your site.
+Largest Contentful Paint (LCP): This measures loading performance. It calculates the time taken for the largest visible content element to render. A good LCP is 2.5 seconds or less.
+Interaction to Next Paint (INP): This measures responsiveness to user input. A good INP is 200 milliseconds or less.
+Cumulative Layout Shift (CLS): This measures the visual stability of the page. It quantifies layout instability during load. A good CLS is 0.1 or less.
+If you want to dive deeper into Core Web Vitals and understand more about their impact on your website's performance, I recommend reading this detailed guide on  New Core Web Vitals and How They Work.
+Next.js Rendering Strategies and Core Web Vitals
+Let's explore each rendering strategy in detail:
+1. Static Rendering (Server Rendering Strategy)
+Static Rendering is the default for Server Components in Next.js. With this approach, components are rendered at build time (or during revalidation), and the resulting HTML is reused for each request. This pre-rendering happens on the server, not in the user's browser. Static rendering is ideal for routes where the data is not personalized to the user, and this makes it suitable for:
+Content-focused websites: Blogs, documentation, marketing pages
+E-commerce product listings: When product details don't change frequently
+SEO-critical pages: When search engine visibility is a priority
+High-traffic pages: When you want to minimize server load
+How Static Rendering Affects Core Web Vitals
+Largest Contentful Paint (LCP): Static rendering typically leads to excellent LCP scores (typically &lt; 1s). The Pre-rendered HTML can be cached and delivered instantly from CDNs, resulting in very fast delivery of the initial content, including the largest element. Also, there is no waiting for data fetching or rendering on the client.
+Interaction to Next Paint (INP): Static rendering provides a good foundation for INP, but doesn't guarantee optimal performance (typically ranges from 50-150 ms depending on implementation). While Server Components don't require hydration, any Client Components within the page still need JavaScript to become interactive. To achieve a very good INP score, you will need to make sure the Client Components within the page is minimal.
+Cumulative Layout Shift (CLS): While static rendering delivers the complete page structure upfront which can be very beneficial for CLS, achieving excellent CLS requires additional optimization strategies:
+Static HTML alone doesn't prevent layout shifts if resources load asynchronously
+Image dimensions must be properly specified to reserve space before the image loads
+Web fonts can cause text to reflow if not handled properly with font display strategies
+Dynamically injected content (ads, embeds, lazy-loaded elements) can disrupt layout stability
+CSS implementation significantly impacts CLS—immediate availability of styling information helps maintain visual stability
+Code Examples:
+Basic static rendering:
+// app/page.tsx (Server Component - Static Rendering by default)
+export default async function Page() {
+  const res = await fetch('https://api.example.com/static-data');
+  const data = await res.json();
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Static Content&lt;/h1&gt;
+      &lt;p&gt;{data.content}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}
+
+Static rendering with revalidation (ISR):
+// app/dashboard/page.tsx
+export default async function Dashboard() {
+  // Static data that revalidates every day
+  const siteStats = await fetch('https://api.example.com/site-stats', {
+    next: { revalidate: 86400 } // 24 hours
+  }).then(r =&gt; r.json());
+
+  // Data that revalidates every hour
+  const popularProducts = await fetch('https://api.example.com/popular-products', {
+    next: { revalidate: 3600 } // 1 hour
+  }).then(r =&gt; r.json());
+
+  // Data with a cache tag for on-demand revalidation
+  const featuredContent = await fetch('https://api.example.com/featured-content', {
+    next: { tags: ['featured'] }
+  }).then(r =&gt; r.json());
+
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      &lt;section className=&quot;stats&quot;&gt;
+        &lt;h2&gt;Site Statistics&lt;/h2&gt;
+        &lt;p&gt;Total Users: {siteStats.totalUsers}&lt;/p&gt;
+        &lt;p&gt;Total Orders: {siteStats.totalOrders}&lt;/p&gt;
+      &lt;/section&gt;
+
+      &lt;section className=&quot;popular&quot;&gt;
+        &lt;h2&gt;Popular Products&lt;/h2&gt;
+        &lt;ul&gt;
+          {popularProducts.map(product =&gt; (
+            &lt;li key={product.id}&gt;{product.name} - {product.sales} sold&lt;/li&gt;
+          ))}
+        &lt;/ul&gt;
+      &lt;/section&gt;
+
+      &lt;section className=&quot;featured&quot;&gt;
+        &lt;h2&gt;Featured Content&lt;/h2&gt;
+        &lt;div&gt;{featuredContent.html}&lt;/div&gt;
+      &lt;/section&gt;
+    &lt;/div&gt;
+  );
+}
+
+Static path generation:
+// app/products/[id]/page.tsx
+export async function generateStaticParams() {
+  const products = await fetch('https://api.example.com/products').then(r =&gt; r.json());
+
+  return products.map((product) =&gt; ({
+    id: product.id.toString(),
+  }));
+}
+
+export default async function Product({ params }) {
+  const product = await fetch(`https://api.example.com/products/${params.id}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;{product.name}&lt;/h1&gt;
+      &lt;p&gt;${product.price.toFixed(2)}&lt;/p&gt;
+      &lt;p&gt;{product.description}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}
+
+2. Dynamic Rendering (Server Rendering Strategy)
+Dynamic Rendering generates HTML on the server for each request at request time. Unlike static rendering, the content is not pre-rendered or cached but freshly generated for each user. This kind of rendering works best for:
+Personalized content: User dashboards, account pages
+Real-time data: Stock prices, live sports scores
+Request-specific information: Pages that use cookies, headers, or search parameters
+Frequently changing data: Content that needs to be up-to-date on every request
+How Dynamic Rendering Affects Core Web Vitals
+Largest Contentful Paint (LCP): With dynamic rendering, the server needs to generate HTML for each request, and that can't be fully cached at the CDN level. It is still faster than client-side rendering as HTML is generated on the server.
+Interaction to Next Paint (INP): The performance is similar to static rendering once the page is loaded. However, it can become slower if the dynamic content includes many Client Components.
+Cumulative Layout Shift (CLS): Dynamic rendering can potentially introduce CLS if the data fetched at request time significantly alters the layout of the page compared to a static structure. However, if the layout is stable and the dynamic content size fits within predefined areas, the CLS can be managed effectively.
+Code Examples:
+Explicit dynamic rendering:
+// app/dashboard/page.tsx
+export const dynamic = 'force-dynamic'; // Force this route to be dynamically rendered
+
+export default async function Dashboard() {
+  // This will run on every request
+  const data = await fetch('https://api.example.com/dashboard-data').then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Dashboard&lt;/h1&gt;
+      &lt;p&gt;Last updated: {new Date().toLocaleString()}&lt;/p&gt;
+      {/* Dashboard content */}
+    &lt;/div&gt;
+  );
+}
+
+Simplicit dynamic rendering with cookies:
+// app/profile/page.tsx
+import { cookies } from 'next/headers';
+
+export default async function Profile() {
+  // Using cookies() automatically opts into dynamic rendering
+  const userId = cookies().get('userId')?.value;
+
+  const user = await fetch(`https://api.example.com/users/${userId}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Welcome, {user.name}&lt;/h1&gt;
+      &lt;p&gt;Email: {user.email}&lt;/p&gt;
+      {/* Profile content */}
+    &lt;/div&gt;
+  );
+}
+
+Dynamic routes:
+// app/blog/[slug]/page.tsx
+export default async function BlogPost({ params }) {
+  // It will run at request time for any slug not explicitly pre-rendered
+  const post = await fetch(`https://api.example.com/posts/${params.slug}`).then(r =&gt; r.json());
+
+  return (
+    &lt;article&gt;
+      &lt;h1&gt;{post.title}&lt;/h1&gt;
+      &lt;div&gt;{post.content}&lt;/div&gt;
+    &lt;/article&gt;
+  );
+}
+
+3. Streaming (Server Rendering Strategy)
+Streaming allows you to progressively render UI from the server. Instead of waiting for all the data to be ready before sending any HTML, the server sends chunks of HTML as they become available. This is implemented using React's Suspense boundary.
+React Suspense works by creating boundaries in your component tree that can &quot;suspend&quot; rendering while waiting for asynchronous operations. When a component inside a Suspense boundary throws a promise (which happens automatically with data fetching in React Server Components), React pauses rendering of that component and its children, renders the fallback UI specified in the Suspense component, continues rendering other parts of the page outside this boundary, and eventually resumes and replaces the fallback with the actual component once the promise resolves.
+When streaming, this mechanism allows the server to send the initial HTML with fallbacks for suspended components while continuing to process suspended components in the background. The server then streams additional HTML chunks as each suspended component resolves, including instructions for the browser to seamlessly replace fallbacks with final content. It works well for:
+Pages with mixed data requirements: Some fast, some slow data sources
+Improving perceived performance: Show users something quickly while slower parts load
+Complex dashboards: Different widgets have different loading times
+Handling slow APIs: Prevent slow third-party services from blocking the entire page
+How Streaming Affects Core Web Vitals
+Largest Contentful Paint (LCP): Streaming can improve the perceived LCP. By sending the initial HTML content quickly, including potentially the largest element, the browser can render it sooner. Even if other parts of the page are still loading, the user sees the main content faster.
+Interaction to Next Paint (INP): Streaming can contribute to a better INP. When used with React's &lt;Suspense /&gt;, interactive elements in the faster-loading parts of the page can become interactive earlier, even while other components are still being streamed in. This allows users to engage with the page sooner.
+Cumulative Layout Shift (CLS): Streaming can cause layout shifts as new content streams in. However, when implemented carefully, streaming should not negatively impact CLS. The initially streamed content should establish the main layout, and subsequent streamed chunks should ideally fit within this structure without causing significant reflows or layout shifts. Using placeholders and ensuring dimensions are known can help prevent CLS.
+Code Examples:
+Basic Streaming with Suspense:
+// app/dashboard/page.tsx
+import { Suspense } from 'react';
+import UserProfile from './components/UserProfile';
+import RecentActivity from './components/RecentActivity';
+import PopularPosts from './components/PopularPosts';
+
+export default function Dashboard() {
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      {/* This loads quickly */}
+      &lt;h1&gt;Dashboard&lt;/h1&gt;
+
+      {/* User profile loads first */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-profile&quot;&gt;Loading profile...&lt;/div&gt;}&gt;
+        &lt;UserProfile /&gt;
+      &lt;/Suspense&gt;
+
+      {/* Recent activity might take longer */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-activity&quot;&gt;Loading activity...&lt;/div&gt;}&gt;
+        &lt;RecentActivity /&gt;
+      &lt;/Suspense&gt;
+
+      {/* Popular posts might be the slowest */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-posts&quot;&gt;Loading popular posts...&lt;/div&gt;}&gt;
+        &lt;PopularPosts /&gt;
+      &lt;/Suspense&gt;
+    &lt;/div&gt;
+  );
+}
+
+Nested Suspense boundaries for more granular control:
+// app/complex-page/page.tsx
+import { Suspense } from 'react';
+
+export default function ComplexPage() {
+  return (
+    &lt;Suspense fallback={&lt;PageSkeleton /&gt;}&gt;
+      &lt;Header /&gt;
+
+      &lt;div className=&quot;content-grid&quot;&gt;
+        &lt;div className=&quot;main-content&quot;&gt;
+          &lt;Suspense fallback={&lt;MainContentSkeleton /&gt;}&gt;
+            &lt;MainContent /&gt;
+          &lt;/Suspense&gt;
+        &lt;/div&gt;
+
+        &lt;div className=&quot;sidebar&quot;&gt;
+          &lt;Suspense fallback={&lt;SidebarTopSkeleton /&gt;}&gt;
+            &lt;SidebarTopSection /&gt;
+          &lt;/Suspense&gt;
+
+          &lt;Suspense fallback={&lt;SidebarBottomSkeleton /&gt;}&gt;
+            &lt;SidebarBottomSection /&gt;
+          &lt;/Suspense&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+
+      &lt;Footer /&gt;
+    &lt;/Suspense&gt;
+  );
+}
+
+Using Next.js loading.js convention:
+// app/products/loading.tsx - This will automatically be used as a Suspense fallback
+export default function Loading() {
+  return (
+    &lt;div className=&quot;products-loading-skeleton&quot;&gt;
+      &lt;div className=&quot;header-skeleton&quot; /&gt;
+      &lt;div className=&quot;filters-skeleton&quot; /&gt;
+      &lt;div className=&quot;products-grid-skeleton&quot;&gt;
+        {Array.from({ length: 12 }).map((_, i) =&gt; (
+          &lt;div key={i} className=&quot;product-card-skeleton&quot; /&gt;
+        ))}
+      &lt;/div&gt;
+    &lt;/div&gt;
+  );
+}
+
+// app/products/page.tsx
+export default async function ProductsPage() {
+  // This component can take time to load
+  // Next.js will automatically wrap it in Suspense
+  // and use the loading.js as the fallback
+  const products = await fetchProducts();
+
+  return &lt;ProductsList products={products} />;
+}
+
+4. Client Components and Client-Side Rendering
+Client Components are defined using the React 'use client' directive. They are pre-rendered on the server but then hydrated on the client, enabling interactivity. This is different from pure client-side rendering (CSR), where rendering happens entirely in the browser. In the traditional sense of CSR (where the initial HTML is minimal, and all rendering happens in the browser), Next.js has moved away from this as a default approach but it can still be achievable by using dynamic imports and setting ssr: false.
+// app/csr-example/page.tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
+
+// Lazily load a component with no SSR
+const ClientOnlyComponent = dynamic(
+  () =&gt; import('../components/heavy-component'),
+  { ssr: false, loading: () =&gt; &lt;p&gt;Loading...&lt;/p&gt; }
+);
+
+export default function CSRPage() {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() =&gt; {
+    setIsClient(true);
+  }, []);
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Client-Side Rendered Page&lt;/h1&gt;
+      {isClient ? (
+        &lt;ClientOnlyComponent /&gt;
+      ) : (
+        &lt;p&gt;Loading client component...&lt;/p&gt;
+      )}
+    &lt;/div&gt;
+  );
+}
+
+Despite the shift toward server rendering, there are valid use cases for CSR:
+Private dashboards: Where SEO doesn't matter, and you want to reduce server load
+Heavy interactive applications: Like data visualization tools or complex editors
+Browser-only APIs: When you need access to browser-specific features like localStorage or WebGL
+Third-party integrations: Some third-party widgets or libraries that only work in the browser
+While these are valid use cases, using Client Components is generally preferable to pure CSR in Next.js. Client Components give you the best of both worlds: server-rendered HTML for the initial load (improving SEO and LCP) with client-side interactivity after hydration. Pure CSR should be reserved for specific scenarios where server rendering is impossible or counterproductive.
+Client components are good for:
+Interactive UI elements: Forms, dropdowns, modals, tabs
+State-dependent UI: Components that change based on client state
+Browser API access: Components that need localStorage, geolocation, etc.
+Event-driven interactions: Click handlers, form submissions, animations
+Real-time updates: Chat interfaces, live notifications
+How Client Components Affect Core Web Vitals
+Largest Contentful Paint (LCP): Initial HTML includes the server-rendered version of Client Components, so LCP is reasonably fast. Hydration can delay interactivity but doesn't necessarily affect LCP.
+Interaction to Next Paint (INP): For Client Components, hydration can cause input delay during page load, and when the page is hydrated, performance depends on the efficiency of event handlers. Also, complex state management can impact responsiveness.
+Cumulative Layout Shift (CLS): Client-side data fetching can cause layout shifts as new data arrives. Also, state changes might alter the layout unexpectedly. Using Client Components will require careful implementation to prevent shifts.
+Code Examples:
+Basic Client Component:
+// app/components/Counter.tsx
+'use client';
+
+import { useState } from 'react';
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    &lt;div&gt;
+      &lt;p&gt;Count: {count}&lt;/p&gt;
+      &lt;button onClick={() =&gt; setCount(count + 1)}&gt;Increment&lt;/button&gt;
+    &lt;/div&gt;
+  );
+}
+
+Client Component with server data:
+// app/products/page.tsx - Server Component
+import ProductFilter from '../components/ProductFilter';
+
+export default async function ProductsPage() {
+  // Fetch data on the server
+  const products = await fetch('https://api.example.com/products').then(r =&gt; r.json());
+
+  // Pass server data to Client Component as props
+  return &lt;ProductFilter initialProducts={products} />;
+}
+
+Hybrid Approaches and Composition Patterns
+In real-world applications, you'll often use a combination of rendering strategies to achieve the best performance. Next.js makes it easy to compose Server and Client Components together.
+Server Components with Islands of Interactivity
+One of the most effective patterns is to use Server Components for the majority of your UI and add Client Components only where interactivity is needed. This approach:
+Minimizes JavaScript sent to the client
+Provides excellent initial load performance
+Maintains good interactivity where needed
+// app/products/[id]/page.tsx - Server Component
+import AddToCartButton from '../../components/AddToCartButton';
+import ProductReviews from '../../components/ProductReviews';
+import RelatedProducts from '../../components/RelatedProducts';
+
+export default async function ProductPage({ params }: {
+  params: { id: string; }
+}) {
+  // Fetch product data on the server
+  const product = await fetch(`https://api.example.com/products/${params.id}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div className=&quot;product-page&quot;&gt;
+      &lt;div className=&quot;product-main&quot;&gt;
+        &lt;h1&gt;{product.name}&lt;/h1&gt;
+        &lt;p className=&quot;price&quot;&gt;${product.price.toFixed(2)}&lt;/p&gt;
+        &lt;div className=&quot;description&quot;&gt;{product.description}&lt;/div&gt;
+
+        {/* Client Component for interactivity */}
+        &lt;AddToCartButton product={product} /&gt;
+      &lt;/div&gt;
+
+      {/* Server Component for product reviews */}
+      &lt;ProductReviews productId={params.id} /&gt;
+
+      {/* Server Component for related products */}
+      &lt;RelatedProducts categoryId={product.categoryId} /&gt;
+    &lt;/div&gt;
+  );
+}
+
+Partial Prerendering (Next.js 15)
+Next.js 15 introduced Partial Prerendering, a new hybrid rendering strategy that combines static and dynamic content in a single route. This allows you to:
+Statically generate a shell of the page
+Stream in dynamic, personalized content
+Get the best of both static and dynamic rendering
+Note: At the time of this writing, Partial Prerendering is experimental and is not ready for production use. Read more
+// app/dashboard/page.tsx
+import { unstable_noStore as noStore } from 'next/cache';
+import StaticContent from './components/StaticContent';
+import DynamicContent from './components/DynamicContent';
+
+export default function Dashboard() {
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      {/* This part is statically generated */}
+      &lt;StaticContent /&gt;
+
+      {/* This part is dynamically rendered */}
+      &lt;DynamicPart /&gt;
+    &lt;/div&gt;
+  );
+}
+
+// This component and its children will be dynamically rendered
+function DynamicPart() {
+  // Opt out of caching for this part
+  noStore();
+
+  return &lt;DynamicContent />;
+}
+
+Measuring Core Web Vitals in Next.js
+Understanding the impact of your rendering strategy choices requires measuring Core Web Vitals in real-world conditions. Here are some approaches:
+1. Vercel Analytics
+If you deploy on Vercel, you can use Vercel Analytics to automatically track Core Web Vitals for your production site:
+// app/layout.tsx
+import { Analytics } from '@vercel/analytics/react';
+
+export default function RootLayout({ children }: {
+  children: React.ReactNode;
+}) {
+  return (
+    &lt;html lang=&quot;en&quot;&gt;
+      &lt;body&gt;
+        {children}
+        &lt;Analytics /&gt;
+      &lt;/body&gt;
+    &lt;/html&gt;
+  );
+}
+
+2. Web Vitals API
+You can manually track Core Web Vitals using the web-vitals library:
+// app/components/WebVitalsReporter.tsx
+'use client';
+
+import { useEffect } from 'react';
+import { onCLS, onINP, onLCP } from 'web-vitals';
+
+export function WebVitalsReporter() {
+  useEffect(() =&gt; {
+    // Report Core Web Vitals
+    onCLS(metric =&gt; console.log('CLS:', metric.value));
+    onINP(metric =&gt; console.log('INP:', metric.value));
+    onLCP(metric =&gt; console.log('LCP:', metric.value));
+
+    // In a real app, you would send these to your analytics service
+  }, []);
+
+  return null; // This component doesn't render anything
+}
+
+3. Lighthouse and PageSpeed Insights
+For development and testing, use:
+Chrome DevTools Lighthouse tab
+PageSpeed Insights
+Chrome User Experience Report
+Making Practical Decisions: Which Rendering Strategy to Choose?
+Choosing the right rendering strategy depends on your specific requirements. Here's a decision framework:
+Choose Static Rendering when
+Content is the same for all users
+Data can be determined at build time
+Page doesn't need frequent updates
+SEO is critical
+You want the best possible performance
+Choose Dynamic Rendering when
+Content is personalized for each user
+Data must be fresh on every request
+You need access to request-time information
+Content changes frequently
+Choose Streaming when
+Page has a mix of fast and slow data requirements
+You want to improve perceived performance
+Some parts of the page depend on slow APIs
+You want to prioritize showing critical UI first
+Choose Client Components when
+UI needs to be interactive
+Component relies on browser APIs
+UI changes frequently based on user input
+You need real-time updates
+Conclusion
+Next.js provides a powerful set of rendering strategies that allow you to optimize for both performance and user experience. By understanding how each strategy affects Core Web Vitals, you can make informed decisions about how to build your application.
+Remember that the best approach is often a hybrid one, combining different rendering strategies based on the specific requirements of each part of your application. Start with Server Components as your default, use Static Rendering where possible, and add Client Components only where interactivity is needed.
+By following these principles and measuring your Core Web Vitals, you can create Next.js applications that are fast, responsive, and provide an excellent user experience.</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://www.thisdot.co/blog/next-js-rendering-strategies-and-how-they-affect-core-web-vitals</guid>
+      <itunes:author>This Dot Labs RSS feed</itunes:author>
+      <itunes:summary>When it comes to building fast and scalable web apps with Next.js, it’s important to understand how rendering works, especially with the App Router. Next.js organizes rendering around two main environments: the server and the client. On the server side, you’ll encounter three key strategies: Static Rendering, Dynamic Rendering, and Streaming. Each one comes with its own set of trade-offs and performance benefits, so knowing when to use which is crucial for delivering a great user experience.
+In this post, we'll break down each strategy, what it's good for, and how it impacts your site's performance, especially Core Web Vitals. We'll also explore hybrid approaches and provide practical guidance on choosing the right strategy for your use case.
+What Are Core Web Vitals?
+Core Web Vitals are a set of metrics defined by Google that measure real-world user experience on websites. These metrics play a major role in search engine rankings and directly affect how users perceive the speed and smoothness of your site.
+Largest Contentful Paint (LCP): This measures loading performance. It calculates the time taken for the largest visible content element to render. A good LCP is 2.5 seconds or less.
+Interaction to Next Paint (INP): This measures responsiveness to user input. A good INP is 200 milliseconds or less.
+Cumulative Layout Shift (CLS): This measures the visual stability of the page. It quantifies layout instability during load. A good CLS is 0.1 or less.
+If you want to dive deeper into Core Web Vitals and understand more about their impact on your website's performance, I recommend reading this detailed guide on  New Core Web Vitals and How They Work.
+Next.js Rendering Strategies and Core Web Vitals
+Let's explore each rendering strategy in detail:
+1. Static Rendering (Server Rendering Strategy)
+Static Rendering is the default for Server Components in Next.js. With this approach, components are rendered at build time (or during revalidation), and the resulting HTML is reused for each request. This pre-rendering happens on the server, not in the user's browser. Static rendering is ideal for routes where the data is not personalized to the user, and this makes it suitable for:
+Content-focused websites: Blogs, documentation, marketing pages
+E-commerce product listings: When product details don't change frequently
+SEO-critical pages: When search engine visibility is a priority
+High-traffic pages: When you want to minimize server load
+How Static Rendering Affects Core Web Vitals
+Largest Contentful Paint (LCP): Static rendering typically leads to excellent LCP scores (typically &lt; 1s). The Pre-rendered HTML can be cached and delivered instantly from CDNs, resulting in very fast delivery of the initial content, including the largest element. Also, there is no waiting for data fetching or rendering on the client.
+Interaction to Next Paint (INP): Static rendering provides a good foundation for INP, but doesn't guarantee optimal performance (typically ranges from 50-150 ms depending on implementation). While Server Components don't require hydration, any Client Components within the page still need JavaScript to become interactive. To achieve a very good INP score, you will need to make sure the Client Components within the page is minimal.
+Cumulative Layout Shift (CLS): While static rendering delivers the complete page structure upfront which can be very beneficial for CLS, achieving excellent CLS requires additional optimization strategies:
+Static HTML alone doesn't prevent layout shifts if resources load asynchronously
+Image dimensions must be properly specified to reserve space before the image loads
+Web fonts can cause text to reflow if not handled properly with font display strategies
+Dynamically injected content (ads, embeds, lazy-loaded elements) can disrupt layout stability
+CSS implementation significantly impacts CLS—immediate availability of styling information helps maintain visual stability
+Code Examples:
+Basic static rendering:
+// app/page.tsx (Server Component - Static Rendering by default)
+export default async function Page() {
+  const res = await fetch('https://api.example.com/static-data');
+  const data = await res.json();
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Static Content&lt;/h1&gt;
+      &lt;p&gt;{data.content}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}
+
+Static rendering with revalidation (ISR):
+// app/dashboard/page.tsx
+export default async function Dashboard() {
+  // Static data that revalidates every day
+  const siteStats = await fetch('https://api.example.com/site-stats', {
+    next: { revalidate: 86400 } // 24 hours
+  }).then(r =&gt; r.json());
+
+  // Data that revalidates every hour
+  const popularProducts = await fetch('https://api.example.com/popular-products', {
+    next: { revalidate: 3600 } // 1 hour
+  }).then(r =&gt; r.json());
+
+  // Data with a cache tag for on-demand revalidation
+  const featuredContent = await fetch('https://api.example.com/featured-content', {
+    next: { tags: ['featured'] }
+  }).then(r =&gt; r.json());
+
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      &lt;section className=&quot;stats&quot;&gt;
+        &lt;h2&gt;Site Statistics&lt;/h2&gt;
+        &lt;p&gt;Total Users: {siteStats.totalUsers}&lt;/p&gt;
+        &lt;p&gt;Total Orders: {siteStats.totalOrders}&lt;/p&gt;
+      &lt;/section&gt;
+
+      &lt;section className=&quot;popular&quot;&gt;
+        &lt;h2&gt;Popular Products&lt;/h2&gt;
+        &lt;ul&gt;
+          {popularProducts.map(product =&gt; (
+            &lt;li key={product.id}&gt;{product.name} - {product.sales} sold&lt;/li&gt;
+          ))}
+        &lt;/ul&gt;
+      &lt;/section&gt;
+
+      &lt;section className=&quot;featured&quot;&gt;
+        &lt;h2&gt;Featured Content&lt;/h2&gt;
+        &lt;div&gt;{featuredContent.html}&lt;/div&gt;
+      &lt;/section&gt;
+    &lt;/div&gt;
+  );
+}
+
+Static path generation:
+// app/products/[id]/page.tsx
+export async function generateStaticParams() {
+  const products = await fetch('https://api.example.com/products').then(r =&gt; r.json());
+
+  return products.map((product) =&gt; ({
+    id: product.id.toString(),
+  }));
+}
+
+export default async function Product({ params }) {
+  const product = await fetch(`https://api.example.com/products/${params.id}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;{product.name}&lt;/h1&gt;
+      &lt;p&gt;${product.price.toFixed(2)}&lt;/p&gt;
+      &lt;p&gt;{product.description}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}
+
+2. Dynamic Rendering (Server Rendering Strategy)
+Dynamic Rendering generates HTML on the server for each request at request time. Unlike static rendering, the content is not pre-rendered or cached but freshly generated for each user. This kind of rendering works best for:
+Personalized content: User dashboards, account pages
+Real-time data: Stock prices, live sports scores
+Request-specific information: Pages that use cookies, headers, or search parameters
+Frequently changing data: Content that needs to be up-to-date on every request
+How Dynamic Rendering Affects Core Web Vitals
+Largest Contentful Paint (LCP): With dynamic rendering, the server needs to generate HTML for each request, and that can't be fully cached at the CDN level. It is still faster than client-side rendering as HTML is generated on the server.
+Interaction to Next Paint (INP): The performance is similar to static rendering once the page is loaded. However, it can become slower if the dynamic content includes many Client Components.
+Cumulative Layout Shift (CLS): Dynamic rendering can potentially introduce CLS if the data fetched at request time significantly alters the layout of the page compared to a static structure. However, if the layout is stable and the dynamic content size fits within predefined areas, the CLS can be managed effectively.
+Code Examples:
+Explicit dynamic rendering:
+// app/dashboard/page.tsx
+export const dynamic = 'force-dynamic'; // Force this route to be dynamically rendered
+
+export default async function Dashboard() {
+  // This will run on every request
+  const data = await fetch('https://api.example.com/dashboard-data').then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Dashboard&lt;/h1&gt;
+      &lt;p&gt;Last updated: {new Date().toLocaleString()}&lt;/p&gt;
+      {/* Dashboard content */}
+    &lt;/div&gt;
+  );
+}
+
+Simplicit dynamic rendering with cookies:
+// app/profile/page.tsx
+import { cookies } from 'next/headers';
+
+export default async function Profile() {
+  // Using cookies() automatically opts into dynamic rendering
+  const userId = cookies().get('userId')?.value;
+
+  const user = await fetch(`https://api.example.com/users/${userId}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Welcome, {user.name}&lt;/h1&gt;
+      &lt;p&gt;Email: {user.email}&lt;/p&gt;
+      {/* Profile content */}
+    &lt;/div&gt;
+  );
+}
+
+Dynamic routes:
+// app/blog/[slug]/page.tsx
+export default async function BlogPost({ params }) {
+  // It will run at request time for any slug not explicitly pre-rendered
+  const post = await fetch(`https://api.example.com/posts/${params.slug}`).then(r =&gt; r.json());
+
+  return (
+    &lt;article&gt;
+      &lt;h1&gt;{post.title}&lt;/h1&gt;
+      &lt;div&gt;{post.content}&lt;/div&gt;
+    &lt;/article&gt;
+  );
+}
+
+3. Streaming (Server Rendering Strategy)
+Streaming allows you to progressively render UI from the server. Instead of waiting for all the data to be ready before sending any HTML, the server sends chunks of HTML as they become available. This is implemented using React's Suspense boundary.
+React Suspense works by creating boundaries in your component tree that can &quot;suspend&quot; rendering while waiting for asynchronous operations. When a component inside a Suspense boundary throws a promise (which happens automatically with data fetching in React Server Components), React pauses rendering of that component and its children, renders the fallback UI specified in the Suspense component, continues rendering other parts of the page outside this boundary, and eventually resumes and replaces the fallback with the actual component once the promise resolves.
+When streaming, this mechanism allows the server to send the initial HTML with fallbacks for suspended components while continuing to process suspended components in the background. The server then streams additional HTML chunks as each suspended component resolves, including instructions for the browser to seamlessly replace fallbacks with final content. It works well for:
+Pages with mixed data requirements: Some fast, some slow data sources
+Improving perceived performance: Show users something quickly while slower parts load
+Complex dashboards: Different widgets have different loading times
+Handling slow APIs: Prevent slow third-party services from blocking the entire page
+How Streaming Affects Core Web Vitals
+Largest Contentful Paint (LCP): Streaming can improve the perceived LCP. By sending the initial HTML content quickly, including potentially the largest element, the browser can render it sooner. Even if other parts of the page are still loading, the user sees the main content faster.
+Interaction to Next Paint (INP): Streaming can contribute to a better INP. When used with React's &lt;Suspense /&gt;, interactive elements in the faster-loading parts of the page can become interactive earlier, even while other components are still being streamed in. This allows users to engage with the page sooner.
+Cumulative Layout Shift (CLS): Streaming can cause layout shifts as new content streams in. However, when implemented carefully, streaming should not negatively impact CLS. The initially streamed content should establish the main layout, and subsequent streamed chunks should ideally fit within this structure without causing significant reflows or layout shifts. Using placeholders and ensuring dimensions are known can help prevent CLS.
+Code Examples:
+Basic Streaming with Suspense:
+// app/dashboard/page.tsx
+import { Suspense } from 'react';
+import UserProfile from './components/UserProfile';
+import RecentActivity from './components/RecentActivity';
+import PopularPosts from './components/PopularPosts';
+
+export default function Dashboard() {
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      {/* This loads quickly */}
+      &lt;h1&gt;Dashboard&lt;/h1&gt;
+
+      {/* User profile loads first */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-profile&quot;&gt;Loading profile...&lt;/div&gt;}&gt;
+        &lt;UserProfile /&gt;
+      &lt;/Suspense&gt;
+
+      {/* Recent activity might take longer */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-activity&quot;&gt;Loading activity...&lt;/div&gt;}&gt;
+        &lt;RecentActivity /&gt;
+      &lt;/Suspense&gt;
+
+      {/* Popular posts might be the slowest */}
+      &lt;Suspense fallback={&lt;div className=&quot;skeleton-posts&quot;&gt;Loading popular posts...&lt;/div&gt;}&gt;
+        &lt;PopularPosts /&gt;
+      &lt;/Suspense&gt;
+    &lt;/div&gt;
+  );
+}
+
+Nested Suspense boundaries for more granular control:
+// app/complex-page/page.tsx
+import { Suspense } from 'react';
+
+export default function ComplexPage() {
+  return (
+    &lt;Suspense fallback={&lt;PageSkeleton /&gt;}&gt;
+      &lt;Header /&gt;
+
+      &lt;div className=&quot;content-grid&quot;&gt;
+        &lt;div className=&quot;main-content&quot;&gt;
+          &lt;Suspense fallback={&lt;MainContentSkeleton /&gt;}&gt;
+            &lt;MainContent /&gt;
+          &lt;/Suspense&gt;
+        &lt;/div&gt;
+
+        &lt;div className=&quot;sidebar&quot;&gt;
+          &lt;Suspense fallback={&lt;SidebarTopSkeleton /&gt;}&gt;
+            &lt;SidebarTopSection /&gt;
+          &lt;/Suspense&gt;
+
+          &lt;Suspense fallback={&lt;SidebarBottomSkeleton /&gt;}&gt;
+            &lt;SidebarBottomSection /&gt;
+          &lt;/Suspense&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+
+      &lt;Footer /&gt;
+    &lt;/Suspense&gt;
+  );
+}
+
+Using Next.js loading.js convention:
+// app/products/loading.tsx - This will automatically be used as a Suspense fallback
+export default function Loading() {
+  return (
+    &lt;div className=&quot;products-loading-skeleton&quot;&gt;
+      &lt;div className=&quot;header-skeleton&quot; /&gt;
+      &lt;div className=&quot;filters-skeleton&quot; /&gt;
+      &lt;div className=&quot;products-grid-skeleton&quot;&gt;
+        {Array.from({ length: 12 }).map((_, i) =&gt; (
+          &lt;div key={i} className=&quot;product-card-skeleton&quot; /&gt;
+        ))}
+      &lt;/div&gt;
+    &lt;/div&gt;
+  );
+}
+
+// app/products/page.tsx
+export default async function ProductsPage() {
+  // This component can take time to load
+  // Next.js will automatically wrap it in Suspense
+  // and use the loading.js as the fallback
+  const products = await fetchProducts();
+
+  return &lt;ProductsList products={products} />;
+}
+
+4. Client Components and Client-Side Rendering
+Client Components are defined using the React 'use client' directive. They are pre-rendered on the server but then hydrated on the client, enabling interactivity. This is different from pure client-side rendering (CSR), where rendering happens entirely in the browser. In the traditional sense of CSR (where the initial HTML is minimal, and all rendering happens in the browser), Next.js has moved away from this as a default approach but it can still be achievable by using dynamic imports and setting ssr: false.
+// app/csr-example/page.tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import dynamic from 'next/dynamic';
+
+// Lazily load a component with no SSR
+const ClientOnlyComponent = dynamic(
+  () =&gt; import('../components/heavy-component'),
+  { ssr: false, loading: () =&gt; &lt;p&gt;Loading...&lt;/p&gt; }
+);
+
+export default function CSRPage() {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() =&gt; {
+    setIsClient(true);
+  }, []);
+
+  return (
+    &lt;div&gt;
+      &lt;h1&gt;Client-Side Rendered Page&lt;/h1&gt;
+      {isClient ? (
+        &lt;ClientOnlyComponent /&gt;
+      ) : (
+        &lt;p&gt;Loading client component...&lt;/p&gt;
+      )}
+    &lt;/div&gt;
+  );
+}
+
+Despite the shift toward server rendering, there are valid use cases for CSR:
+Private dashboards: Where SEO doesn't matter, and you want to reduce server load
+Heavy interactive applications: Like data visualization tools or complex editors
+Browser-only APIs: When you need access to browser-specific features like localStorage or WebGL
+Third-party integrations: Some third-party widgets or libraries that only work in the browser
+While these are valid use cases, using Client Components is generally preferable to pure CSR in Next.js. Client Components give you the best of both worlds: server-rendered HTML for the initial load (improving SEO and LCP) with client-side interactivity after hydration. Pure CSR should be reserved for specific scenarios where server rendering is impossible or counterproductive.
+Client components are good for:
+Interactive UI elements: Forms, dropdowns, modals, tabs
+State-dependent UI: Components that change based on client state
+Browser API access: Components that need localStorage, geolocation, etc.
+Event-driven interactions: Click handlers, form submissions, animations
+Real-time updates: Chat interfaces, live notifications
+How Client Components Affect Core Web Vitals
+Largest Contentful Paint (LCP): Initial HTML includes the server-rendered version of Client Components, so LCP is reasonably fast. Hydration can delay interactivity but doesn't necessarily affect LCP.
+Interaction to Next Paint (INP): For Client Components, hydration can cause input delay during page load, and when the page is hydrated, performance depends on the efficiency of event handlers. Also, complex state management can impact responsiveness.
+Cumulative Layout Shift (CLS): Client-side data fetching can cause layout shifts as new data arrives. Also, state changes might alter the layout unexpectedly. Using Client Components will require careful implementation to prevent shifts.
+Code Examples:
+Basic Client Component:
+// app/components/Counter.tsx
+'use client';
+
+import { useState } from 'react';
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    &lt;div&gt;
+      &lt;p&gt;Count: {count}&lt;/p&gt;
+      &lt;button onClick={() =&gt; setCount(count + 1)}&gt;Increment&lt;/button&gt;
+    &lt;/div&gt;
+  );
+}
+
+Client Component with server data:
+// app/products/page.tsx - Server Component
+import ProductFilter from '../components/ProductFilter';
+
+export default async function ProductsPage() {
+  // Fetch data on the server
+  const products = await fetch('https://api.example.com/products').then(r =&gt; r.json());
+
+  // Pass server data to Client Component as props
+  return &lt;ProductFilter initialProducts={products} />;
+}
+
+Hybrid Approaches and Composition Patterns
+In real-world applications, you'll often use a combination of rendering strategies to achieve the best performance. Next.js makes it easy to compose Server and Client Components together.
+Server Components with Islands of Interactivity
+One of the most effective patterns is to use Server Components for the majority of your UI and add Client Components only where interactivity is needed. This approach:
+Minimizes JavaScript sent to the client
+Provides excellent initial load performance
+Maintains good interactivity where needed
+// app/products/[id]/page.tsx - Server Component
+import AddToCartButton from '../../components/AddToCartButton';
+import ProductReviews from '../../components/ProductReviews';
+import RelatedProducts from '../../components/RelatedProducts';
+
+export default async function ProductPage({ params }: {
+  params: { id: string; }
+}) {
+  // Fetch product data on the server
+  const product = await fetch(`https://api.example.com/products/${params.id}`).then(r =&gt; r.json());
+
+  return (
+    &lt;div className=&quot;product-page&quot;&gt;
+      &lt;div className=&quot;product-main&quot;&gt;
+        &lt;h1&gt;{product.name}&lt;/h1&gt;
+        &lt;p className=&quot;price&quot;&gt;${product.price.toFixed(2)}&lt;/p&gt;
+        &lt;div className=&quot;description&quot;&gt;{product.description}&lt;/div&gt;
+
+        {/* Client Component for interactivity */}
+        &lt;AddToCartButton product={product} /&gt;
+      &lt;/div&gt;
+
+      {/* Server Component for product reviews */}
+      &lt;ProductReviews productId={params.id} /&gt;
+
+      {/* Server Component for related products */}
+      &lt;RelatedProducts categoryId={product.categoryId} /&gt;
+    &lt;/div&gt;
+  );
+}
+
+Partial Prerendering (Next.js 15)
+Next.js 15 introduced Partial Prerendering, a new hybrid rendering strategy that combines static and dynamic content in a single route. This allows you to:
+Statically generate a shell of the page
+Stream in dynamic, personalized content
+Get the best of both static and dynamic rendering
+Note: At the time of this writing, Partial Prerendering is experimental and is not ready for production use. Read more
+// app/dashboard/page.tsx
+import { unstable_noStore as noStore } from 'next/cache';
+import StaticContent from './components/StaticContent';
+import DynamicContent from './components/DynamicContent';
+
+export default function Dashboard() {
+  return (
+    &lt;div className=&quot;dashboard&quot;&gt;
+      {/* This part is statically generated */}
+      &lt;StaticContent /&gt;
+
+      {/* This part is dynamically rendered */}
+      &lt;DynamicPart /&gt;
+    &lt;/div&gt;
+  );
+}
+
+// This component and its children will be dynamically rendered
+function DynamicPart() {
+  // Opt out of caching for this part
+  noStore();
+
+  return &lt;DynamicContent />;
+}
+
+Measuring Core Web Vitals in Next.js
+Understanding the impact of your rendering strategy choices requires measuring Core Web Vitals in real-world conditions. Here are some approaches:
+1. Vercel Analytics
+If you deploy on Vercel, you can use Vercel Analytics to automatically track Core Web Vitals for your production site:
+// app/layout.tsx
+import { Analytics } from '@vercel/analytics/react';
+
+export default function RootLayout({ children }: {
+  children: React.ReactNode;
+}) {
+  return (
+    &lt;html lang=&quot;en&quot;&gt;
+      &lt;body&gt;
+        {children}
+        &lt;Analytics /&gt;
+      &lt;/body&gt;
+    &lt;/html&gt;
+  );
+}
+
+2. Web Vitals API
+You can manually track Core Web Vitals using the web-vitals library:
+// app/components/WebVitalsReporter.tsx
+'use client';
+
+import { useEffect } from 'react';
+import { onCLS, onINP, onLCP } from 'web-vitals';
+
+export function WebVitalsReporter() {
+  useEffect(() =&gt; {
+    // Report Core Web Vitals
+    onCLS(metric =&gt; console.log('CLS:', metric.value));
+    onINP(metric =&gt; console.log('INP:', metric.value));
+    onLCP(metric =&gt; console.log('LCP:', metric.value));
+
+    // In a real app, you would send these to your analytics service
+  }, []);
+
+  return null; // This component doesn't render anything
+}
+
+3. Lighthouse and PageSpeed Insights
+For development and testing, use:
+Chrome DevTools Lighthouse tab
+PageSpeed Insights
+Chrome User Experience Report
+Making Practical Decisions: Which Rendering Strategy to Choose?
+Choosing the right rendering strategy depends on your specific requirements. Here's a decision framework:
+Choose Static Rendering when
+Content is the same for all users
+Data can be determined at build time
+Page doesn't need frequent updates
+SEO is critical
+You want the best possible performance
+Choose Dynamic Rendering when
+Content is personalized for each user
+Data must be fresh on every request
+You need access to request-time information
+Content changes frequently
+Choose Streaming when
+Page has a mix of fast and slow data requirements
+You want to improve perceived performance
+Some parts of the page depend on slow APIs
+You want to prioritize showing critical UI first
+Choose Client Components when
+UI needs to be interactive
+Component relies on browser APIs
+UI changes frequently based on user input
+You need real-time updates
+Conclusion
+Next.js provides a powerful set of rendering strategies that allow you to optimize for both performance and user experience. By understanding how each strategy affects Core Web Vitals, you can make informed decisions about how to build your application.
+Remember that the best approach is often a hybrid one, combining different rendering strategies based on the specific requirements of each part of your application. Start with Server Components as your default, use Static Rendering where possible, and add Client Components only where interactivity is needed.
+By following these principles and measuring your Core Web Vitals, you can create Next.js applications that are fast, responsive, and provide an excellent user experience.</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>666: What Are the Evils of the Web Platform?</title>
+      <link>https://shoptalkshow.com/666/</link>
+      <description>Show Description
+How it all comes back to the why column, dark patterns, privacy and tracking, getting emails forever from one purchase, how to be bold with communication while still being respectful, HTMHell, CSS mistakes, are we anti-JSON, and the state of FitVid in 2025.
+Listen on Website →
+Links
+
+Markup from hell - HTMHell
+Incomplete List of Mistakes in the Design of CSS [CSS Working Group Wiki]
+JSON Editing
+Douglas Crockford on JSON
+Fluid Video Plugin
+Sponsors</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://shoptalkshow.com/666/</guid>
+      <enclosure url="https://shoptalkshow.com/podcast-download/8228/666.mp3?nocache" type="audio/mpeg" length="0"/>
+      <itunes:author>ShopTalk</itunes:author>
+      <itunes:summary>Show Description
+How it all comes back to the why column, dark patterns, privacy and tracking, getting emails forever from one purchase, how to be bold with communication while still being respectful, HTMHell, CSS mistakes, are we anti-JSON, and the state of FitVid in 2025.
+Listen on Website →
+Links
+
+Markup from hell - HTMHell
+Incomplete List of Mistakes in the Design of CSS [CSS Working Group Wiki]
+JSON Editing
+Douglas Crockford on JSON
+Fluid Video Plugin
+Sponsors</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Episode 462: Supporting laid-off employee and how to rebuild culture after layoffs</title>
+      <link>https://softskills.audio/2025/05/26/episode-462-supporting-laid-off-employee-and-how-to-rebuild-culture-after-layoffs/</link>
+      <description>In this episode, Dave and Jamison answer these questions:
+One of my employees is probably getting laid off, what do I do!?!
+I’m a tech lead / manager for a consultancy and a contract reduction means that one of the people I supervise is likely going to get laid off soon! We’ve found new roles for most of my people, but it’s likely that at least one will get laid off.
+I want to help this person out. How much support is typical for a manager / ex-manager to provide in a job search, and how can I go above and beyond without doing too much?
+Over the last year, my company has gone through 3 rounds of layoff. The engineering culture has changed dramatically. With the fraction of engineers remaining, I am increasingly concerned that it’s going to be me next. The company’s posture is that everything is “business as usual” and there is nothing to be worried about, but this is what has been said all along. Morale seems to be low with low engagement in department initiatives.
+I am looking for some advice here, if I stay with the company – what is a healthy way to engage with the current culture to build it back up (or evolve it into something new)? If I decide to leave the company – how can I set proper boundaries to prepare for leaving, but remain engaged until a new opportunity arises?</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://softskills.audio/2025/05/26/episode-462-supporting-laid-off-employee-and-how-to-rebuild-culture-after-layoffs/</guid>
+      <enclosure url="https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-462.mp3?source=rss" type="audio/mpeg" length="0"/>
+      <itunes:author>Soft Skills Engineering</itunes:author>
+      <itunes:summary>In this episode, Dave and Jamison answer these questions:
+One of my employees is probably getting laid off, what do I do!?!
+I’m a tech lead / manager for a consultancy and a contract reduction means that one of the people I supervise is likely going to get laid off soon! We’ve found new roles for most of my people, but it’s likely that at least one will get laid off.
+I want to help this person out. How much support is typical for a manager / ex-manager to provide in a job search, and how can I go above and beyond without doing too much?
+Over the last year, my company has gone through 3 rounds of layoff. The engineering culture has changed dramatically. With the fraction of engineers remaining, I am increasingly concerned that it’s going to be me next. The company’s posture is that everything is “business as usual” and there is nothing to be worried about, but this is what has been said all along. Morale seems to be low with low engagement in department initiatives.
+I am looking for some advice here, if I stay with the company – what is a healthy way to engage with the current culture to build it back up (or evolve it into something new)? If I decide to leave the company – how can I set proper boundaries to prepare for leaving, but remain engaged until a new opportunity arises?</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>VS Code Open Sources GitHub Copilot Chat</title>
+      <link>https://www.buzzsprout.com/2226499</link>
+      <description>This week both Google and Microsoft held conferences where they announced all the new, great AI breakthroughs, but there were a few other notable, web dev-focused pieces in between. VS Code announced it will be open sourcing the GitHub Copilot Chat extension, refactoring relevant components into its core codebase, as the next logical step “in making VS Code an open source AI editor.”
+Microsoft has floated a new idea called “NLWeb” to make it easier for websites to turn themselves into AI apps using an LLM model and their own data. While this sounds interesting, it’s very early days yet and is not ready for prime time.
+A blog post from Remix creator Ryan Florence leaked earlier this week, and in it, Ryan shares that Remix v3 will move away from using React. The usual criticisms of React are present, and so Remix v3 will be completely new with a focus on a framework that’s AI friendly and leveraging all the Web APIs available today. 
+News:
+
+VS Code is open sourcing its AI chat extension
+Remix’s “Declaration of Independence” blog leaked
+And Microsoft introduces yet another AI standard
+
+Lightning News:
+
+Satya Nadella and podcasts
+Introducing Claude 4 
+
+What Makes Us Happy this Week:
+
+Paige - Daredevil: Born Again TV series
+Jack -  Baseball team Portland Pickles’ Red Head Appreciation Night
+TJ - The Philadelphia Inquirer’s summer reading list
+
+Thanks as always to our sponsor, the Blue Collar Coder channel on YouTube. You can join us in our Discord channel, explore our website and reach us via email, or talk to us on X, Bluesky, or YouTube.
+
+Front-end Fire website
+Blue Collar Coder on YouTube
+Blue Collar Coder on Discord
+Reach out via email
+Tweet at us on X @front_end_fire
+Follow us on Bluesky @front-end-fire.com
+Subscribe to our YouTube channel @Front-EndFirePodcast</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://www.buzzsprout.com/2226499</guid>
+      <enclosure url="https://www.buzzsprout.com/2226499/episodes/17225284-vs-code-open-sources-github-copilot-chat.mp3" type="audio/mpeg" length="0"/>
+      <itunes:author>Front-End Fire</itunes:author>
+      <itunes:summary>This week both Google and Microsoft held conferences where they announced all the new, great AI breakthroughs, but there were a few other notable, web dev-focused pieces in between. VS Code announced it will be open sourcing the GitHub Copilot Chat extension, refactoring relevant components into its core codebase, as the next logical step “in making VS Code an open source AI editor.”
+Microsoft has floated a new idea called “NLWeb” to make it easier for websites to turn themselves into AI apps using an LLM model and their own data. While this sounds interesting, it’s very early days yet and is not ready for prime time.
+A blog post from Remix creator Ryan Florence leaked earlier this week, and in it, Ryan shares that Remix v3 will move away from using React. The usual criticisms of React are present, and so Remix v3 will be completely new with a focus on a framework that’s AI friendly and leveraging all the Web APIs available today. 
+News:
+
+VS Code is open sourcing its AI chat extension
+Remix’s “Declaration of Independence” blog leaked
+And Microsoft introduces yet another AI standard
+
+Lightning News:
+
+Satya Nadella and podcasts
+Introducing Claude 4 
+
+What Makes Us Happy this Week:
+
+Paige - Daredevil: Born Again TV series
+Jack -  Baseball team Portland Pickles’ Red Head Appreciation Night
+TJ - The Philadelphia Inquirer’s summer reading list
+
+Thanks as always to our sponsor, the Blue Collar Coder channel on YouTube. You can join us in our Discord channel, explore our website and reach us via email, or talk to us on X, Bluesky, or YouTube.
+
+Front-end Fire website
+Blue Collar Coder on YouTube
+Blue Collar Coder on Discord
+Reach out via email
+Tweet at us on X @front_end_fire
+Follow us on Bluesky @front-end-fire.com
+Subscribe to our YouTube channel @Front-EndFirePodcast</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Building a TikTok-Style App with React Native &amp; Expo: Interview w Skylight Social CTO, Reed Harmeyer</title>
+      <link>https://podcasters.spotify.com/pod/show/modern-web/episodes/Building-a-TikTok-Style-App-with-React-Native--Expo-Interview-w-Skylight-Social-CTO--Reed-Harmeyer-e33g1fu</link>
+      <description>In this episode of the Modern Web Podcast, Danny Thompson sits down with Reed Harmeyer, CTO of Skylight Social, and Brandon Mathis, React Native engineer at This Dot Labs. They unpack the technical and strategic decisions behind Skylight’s meteoric growth: why they built on the AT Protocol, how they tackled video discovery and scaling challenges, and how a fast-tracked in-app video editor gave them an edge.
+
+
+Keypoints from this episode:
+
+Skylight Social was built on the AT Protocol, allowing users to retain followers across platforms like Blue Sky and enabling creators to publish interoperable content in a decentralized social network.
+
+The team used React Native with Expo to achieve rapid development and cross-platform performance—launching a high-quality, TikTok-like video experience in just days.
+
+An in-app video editor was prioritized to reduce friction for creators, built using a native SDK wrapped with Expo Modules, enabling features like clip rearranging, overlays, voiceovers, and AI-generated captions.
+
+User behavior data—specifically watch time—drives content recommendations, not just likes or follows, helping Skylight offer a personalized experience while navigating scaling challenges from hypergrowth.
+
+
+
+Follow Reed Harmeyer on Social Media
+Bluesky: https://bsky.app/profile/reedharmeyer.bsky.social
+Linkedin: https://www.linkedin.com/in/reed-harmeyer/</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://podcasters.spotify.com/pod/show/modern-web/episodes/Building-a-TikTok-Style-App-with-React-Native--Expo-Interview-w-Skylight-Social-CTO--Reed-Harmeyer-e33g1fu</guid>
+      <enclosure url="https://anchor.fm/s/f9191780/podcast/play/103334846/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2025-4-28%2F401165513-44100-2-ec812e0f97d61.mp3" type="audio/mpeg" length="0"/>
+      <itunes:author>Modern Web</itunes:author>
+      <itunes:summary>In this episode of the Modern Web Podcast, Danny Thompson sits down with Reed Harmeyer, CTO of Skylight Social, and Brandon Mathis, React Native engineer at This Dot Labs. They unpack the technical and strategic decisions behind Skylight’s meteoric growth: why they built on the AT Protocol, how they tackled video discovery and scaling challenges, and how a fast-tracked in-app video editor gave them an edge.
+
+
+Keypoints from this episode:
+
+Skylight Social was built on the AT Protocol, allowing users to retain followers across platforms like Blue Sky and enabling creators to publish interoperable content in a decentralized social network.
+
+The team used React Native with Expo to achieve rapid development and cross-platform performance—launching a high-quality, TikTok-like video experience in just days.
+
+An in-app video editor was prioritized to reduce friction for creators, built using a native SDK wrapped with Expo Modules, enabling features like clip rearranging, overlays, voiceovers, and AI-generated captions.
+
+User behavior data—specifically watch time—drives content recommendations, not just likes or follows, helping Skylight offer a personalized experience while navigating scaling challenges from hypergrowth.
+
+
+
+Follow Reed Harmeyer on Social Media
+Bluesky: https://bsky.app/profile/reedharmeyer.bsky.social
+Linkedin: https://www.linkedin.com/in/reed-harmeyer/</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Greg Sadetsky, Antonie Leclair - Disco</title>
+      <link>https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Greg-Sadetsky--Antonie-Leclair---Disco-e33bjbd</link>
+      <description>This week we talk to Greg Sadetsky and Antoine Leclair, the creators of Disco. Disco make running you own infra a piece of cake.
+
+https://disco.cloud/
+https://docs.letsdisco.dev/
+https://github.com/letsdiscodev/
+https://github.com/gregsadetsky
+https://github.com/antoineleclair
+
+
+Episode sponsored By WorkOS (https://workos.com).
+Become a paid subscriber our patreon, spotify, or apple podcasts for the full episode.
+
+https://www.patreon.com/devtoolsfm
+https://podcasters.spotify.com/pod/show/devtoolsfm/subscribe
+https://podcasts.apple.com/us/podcast/devtools-fm/id1566647758
+https://www.youtube.com/@devtoolsfm/membership</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Greg-Sadetsky--Antonie-Leclair---Disco-e33bjbd</guid>
+      <enclosure url="https://anchor.fm/s/dd6922b4/podcast/play/103189293/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2025-4-25%2F400981004-44100-2-dad9bdc59c9aa.m4a" type="audio/mpeg" length="0"/>
+      <itunes:author>devtools.fm: Developer Tools, Open Source, Software Development</itunes:author>
+      <itunes:summary>This week we talk to Greg Sadetsky and Antoine Leclair, the creators of Disco. Disco make running you own infra a piece of cake.
+
+https://disco.cloud/
+https://docs.letsdisco.dev/
+https://github.com/letsdiscodev/
+https://github.com/gregsadetsky
+https://github.com/antoineleclair
+
+
+Episode sponsored By WorkOS (https://workos.com).
+Become a paid subscriber our patreon, spotify, or apple podcasts for the full episode.
+
+https://www.patreon.com/devtoolsfm
+https://podcasters.spotify.com/pod/show/devtoolsfm/subscribe
+https://podcasts.apple.com/us/podcast/devtools-fm/id1566647758
+https://www.youtube.com/@devtoolsfm/membership</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Relatively new things you should know about HTML with Chris Coyier (Repeat)</title>
+      <link>http://podrocket.logrocket.com/relatively-new-things-you-should-know-about-html-chris-coyier-repeat</link>
+      <description>In this repeat episode, Chris Coyier, co-founder of CodePen, talks about the evolving landscape of HTML heading into 2025. He delves into topics like the slow evolution of HTML compared to CSS and JavaScript, the importance of backwards compatibility, new HTML elements and pseudo-elements, and the potential of declarative shadow DOM for server-side rendering in web components.
+Links
+Website: https://chriscoyier.net
+Codepen: https://codepen.io/chriscoyier
+Frontend Social: https://front-end.social/@chriscoyier
+Github: https://github.com/chriscoyier
+Threads: https://www.threads.net/@chriscoyier
+Bluesky: https://bsky.app/profile/chriscoyier.net
+We want to hear from you!
+How did you find us? Did you see us on Twitter? In a newsletter? Or maybe we were recommended by a friend?
+Let us know by sending an email to our producer, Em, at emily.kochanek@logrocket.com (mailto:emily.kochanek@logrocket.com), or tweet at us at PodRocketPod (https://twitter.com/PodRocketpod).
+Follow us. Get free stickers.
+Follow us on Apple Podcasts, fill out this form (https://podrocket.logrocket.com/get-podrocket-stickers), and we’ll send you free PodRocket stickers!
+What does LogRocket do?
+LogRocket provides AI-first session replay and analytics that surfaces the UX and technical issues impacting user experiences. Start understanding where your users are struggling by trying it for free at LogRocket.com. Try LogRocket for free today. (https://logrocket.com/signup/?pdr) Special Guest: Chris Coyier.</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>http://podrocket.logrocket.com/relatively-new-things-you-should-know-about-html-chris-coyier-repeat</guid>
+      <enclosure url="https://chrt.fm/track/7F1212/aphid.fireside.fm/d/1437767933/3911462c-bca2-48c2-9103-610ba304c673/91d26313-24a6-4ffa-bef9-1f249a04342e.mp3" type="audio/mpeg" length="0"/>
+      <itunes:author>PodRocket - A web development podcast from LogRocket</itunes:author>
+      <itunes:summary>In this repeat episode, Chris Coyier, co-founder of CodePen, talks about the evolving landscape of HTML heading into 2025. He delves into topics like the slow evolution of HTML compared to CSS and JavaScript, the importance of backwards compatibility, new HTML elements and pseudo-elements, and the potential of declarative shadow DOM for server-side rendering in web components.
+Links
+Website: https://chriscoyier.net
+Codepen: https://codepen.io/chriscoyier
+Frontend Social: https://front-end.social/@chriscoyier
+Github: https://github.com/chriscoyier
+Threads: https://www.threads.net/@chriscoyier
+Bluesky: https://bsky.app/profile/chriscoyier.net
+We want to hear from you!
+How did you find us? Did you see us on Twitter? In a newsletter? Or maybe we were recommended by a friend?
+Let us know by sending an email to our producer, Em, at emily.kochanek@logrocket.com (mailto:emily.kochanek@logrocket.com), or tweet at us at PodRocketPod (https://twitter.com/PodRocketpod).
+Follow us. Get free stickers.
+Follow us on Apple Podcasts, fill out this form (https://podrocket.logrocket.com/get-podrocket-stickers), and we’ll send you free PodRocket stickers!
+What does LogRocket do?
+LogRocket provides AI-first session replay and analytics that surfaces the UX and technical issues impacting user experiences. Start understanding where your users are struggling by trying it for free at LogRocket.com. Try LogRocket for free today. (https://logrocket.com/signup/?pdr) Special Guest: Chris Coyier.</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>TypeScript, Security, and Type Juggling with Ariel Shulman &amp; Liran Tal - JSJ 679</title>
+      <link>https://www.spreaker.com/episode/typescript-security-and-type-juggling-with-ariel-shulman-liran-tal-jsj-679--66327148</link>
+      <description>In this episode, we dove headfirst into the swirling waters of TypeScript, its real-world use cases, and where it starts to fall short—especially when it comes to security. Joining us from sunny Tel Aviv (and a slightly cooler Portland), we had the brilliant Ariel Shulman and security advocate Liran Tal bring the heat on everything from type safety to runtime vulnerabilities.
+
+We started off with a friendly debate: Has TypeScript really taken over the world? Our verdict? Pretty much. Whether it’s starter projects, enterprise codebases, or AI-generated snippets, TypeScript has become the de facto standard. But as we quickly found out, that doesn’t mean it’s perfect.
+
+Key Takeaways:
+-TypeScript ≠ Security
+We tend to trust TypeScript a bit too much. It’s a build-time tool, not a runtime enforcer. As Liran pointed out, “TypeScript is not a security tool,” and treating it like one leads to dangerous assumptions.
+-Type Juggling is Real (and Sneaky)
+We explored how something as innocent as using as string on request data can open the door to vulnerabilities like HTTP parameter pollution and prototype pollution. Just because your IDE is happy doesn’t mean your runtime is.
+-Enter Zod – Runtime Type Checking to the Rescue?
+Zod got some love for bridging the dev-time/runtime gap by validating data on the fly and inferring TypeScript types. But even Zod isn’t foolproof. For example, unless you're using .strict(), extra fields can sneak past your validations, leading to mass assignment bugs.
+-Common Developer Fallacies
+We discussed the misplaced confidence developers have in things like code coverage and TypeScript alone. One of the big takeaways: defense in depth matters. Just like testing, layering your security practices (like using Zod, type guards, and proper sanitization) is key.
+-TypeScript Best Practices Are Evolving
+From discriminated unions to avoiding any, from using Maps over plain objects to prevent prototype pollution—TypeScript developers are adapting. And tools like modern Node.js now support type stripping, which makes working with .ts files at runtime a bit easier.
+
+Become a supporter of this podcast: https://www.spreaker.com/podcast/javascript-jabber--6102064/support.</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://www.spreaker.com/episode/typescript-security-and-type-juggling-with-ariel-shulman-liran-tal-jsj-679--66327148</guid>
+      <enclosure url="https://dts.podtrac.com/redirect.mp3/api.spreaker.com/download/episode/66327148/jsj_679.mp3" type="audio/mpeg" length="0"/>
+      <itunes:author>JavaScript Jabber</itunes:author>
+      <itunes:summary>In this episode, we dove headfirst into the swirling waters of TypeScript, its real-world use cases, and where it starts to fall short—especially when it comes to security. Joining us from sunny Tel Aviv (and a slightly cooler Portland), we had the brilliant Ariel Shulman and security advocate Liran Tal bring the heat on everything from type safety to runtime vulnerabilities.
+
+We started off with a friendly debate: Has TypeScript really taken over the world? Our verdict? Pretty much. Whether it’s starter projects, enterprise codebases, or AI-generated snippets, TypeScript has become the de facto standard. But as we quickly found out, that doesn’t mean it’s perfect.
+
+Key Takeaways:
+-TypeScript ≠ Security
+We tend to trust TypeScript a bit too much. It’s a build-time tool, not a runtime enforcer. As Liran pointed out, “TypeScript is not a security tool,” and treating it like one leads to dangerous assumptions.
+-Type Juggling is Real (and Sneaky)
+We explored how something as innocent as using as string on request data can open the door to vulnerabilities like HTTP parameter pollution and prototype pollution. Just because your IDE is happy doesn’t mean your runtime is.
+-Enter Zod – Runtime Type Checking to the Rescue?
+Zod got some love for bridging the dev-time/runtime gap by validating data on the fly and inferring TypeScript types. But even Zod isn’t foolproof. For example, unless you're using .strict(), extra fields can sneak past your validations, leading to mass assignment bugs.
+-Common Developer Fallacies
+We discussed the misplaced confidence developers have in things like code coverage and TypeScript alone. One of the big takeaways: defense in depth matters. Just like testing, layering your security practices (like using Zod, type guards, and proper sanitization) is key.
+-TypeScript Best Practices Are Evolving
+From discriminated unions to avoiding any, from using Maps over plain objects to prevent prototype pollution—TypeScript developers are adapting. And tools like modern Node.js now support type stripping, which makes working with .ts files at runtime a bit easier.
+
+Become a supporter of this podcast: https://www.spreaker.com/podcast/javascript-jabber--6102064/support.</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>906: Tech Startups and Raising Money with Dan Levine (Vercel, Sentry, Mux…)</title>
+      <link>https://syntax.fm/906</link>
+      <description>Wes and Scott talk with VC Dan Levine about how developers can raise venture capital, what investors look for in early-stage startups, the realities of bootstrapping vs. fundraising, and why great ideas often start as simple side projects.
+ Show Notes
+  
+ 00:00 Welcome to Syntax!
+  00:55 Dan’s background and career
+  03:10 Is it common for tech investors to come from a tech background?
+  04:40 How can developers raise money?
+  08:35 What investors look for
+  12:39 How much funding is enough?
+  15:41 Are founders working with multiple investors?
+  18:26 What can you use the money for?
+  22:49 How much influence do investors have in the business?
+  29:56 Brought to you by Sentry.io
+  29:56 How involved are VCs in the business?
+  34:22 How do you know a startup is in trouble—and what can you do about it?
+  38:56 How much of the company do investors own?
+  40:43 What’s the endgame for investors?
+  44:02 How do acqui-hires work?
+  46:29 Is the AI space a real opportunity or just hype?
+  53:22 Sick Picks + Shameless Plugs
+  
+ Sick Picks
+  
+ Dan: 
+  Dandelion Chocolate
+  Jules Pizza
+  
+  
+ Shameless Plugs
+  
+ Dan: Linear
+  
+ Hit us up on Socials!
+  Syntax: X Instagram Tiktok LinkedIn Threads
+  Wes: X Instagram Tiktok LinkedIn Threads
+  Scott: X Instagram Tiktok LinkedIn Threads
+  Randy: X Instagram YouTube Threads</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://syntax.fm/906</guid>
+      <enclosure url="https://traffic.libsyn.com/secure/syntax/Syntax_-_906.mp3?dest-id=532671" type="audio/mpeg" length="0"/>
+      <itunes:author>Syntax - Tasty Web Development Treats</itunes:author>
+      <itunes:summary>Wes and Scott talk with VC Dan Levine about how developers can raise venture capital, what investors look for in early-stage startups, the realities of bootstrapping vs. fundraising, and why great ideas often start as simple side projects.
+ Show Notes
+  
+ 00:00 Welcome to Syntax!
+  00:55 Dan’s background and career
+  03:10 Is it common for tech investors to come from a tech background?
+  04:40 How can developers raise money?
+  08:35 What investors look for
+  12:39 How much funding is enough?
+  15:41 Are founders working with multiple investors?
+  18:26 What can you use the money for?
+  22:49 How much influence do investors have in the business?
+  29:56 Brought to you by Sentry.io
+  29:56 How involved are VCs in the business?
+  34:22 How do you know a startup is in trouble—and what can you do about it?
+  38:56 How much of the company do investors own?
+  40:43 What’s the endgame for investors?
+  44:02 How do acqui-hires work?
+  46:29 Is the AI space a real opportunity or just hype?
+  53:22 Sick Picks + Shameless Plugs
+  
+ Sick Picks
+  
+ Dan: 
+  Dandelion Chocolate
+  Jules Pizza
+  
+  
+ Shameless Plugs
+  
+ Dan: Linear
+  
+ Hit us up on Socials!
+  Syntax: X Instagram Tiktok LinkedIn Threads
+  Wes: X Instagram Tiktok LinkedIn Threads
+  Scott: X Instagram Tiktok LinkedIn Threads
+  Randy: X Instagram YouTube Threads</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>905: You Should Learn Nuxt!</title>
+      <link>https://syntax.fm/905</link>
+      <description>CJ steps in for Scott and joins Wes to share his experience working with Nuxt, from routing and data fetching to the pros and cons of the framework. They break down the Nuxt ecosystem, directory structure, and how it handles server routes and modules.
+ Show Notes
+  
+ 00:00 Syntax Meetup!
+  00:26 Welcome to Syntax
+  01:21 The deal with Nuxt. 
+  CJ’s Nuxt Course.
+  
+  02:51 Why do you like Vue?
+  04:52 Brought to you by Sentry.io.
+  05:17 Routing with Nuxt. 
+  h3 - The Web Framework for Modern JavaScript Era.
+  Nuxt Guides.
+  
+  06:12 Built on Nitro.
+  06:49 The Nuxt Ecosystem.
+  07:52 API Route Support.
+  08:15 Nuxt Directory Structure.
+  09:09 Does Nuxt do too much for you?
+  11:15 Data fetching in a Nuxt app.
+  13:25 RPC, Form Actions, Server Actions?
+  15:00 Nuxt Server Folder Hastle.
+  15:57 useFetch Hook. 
+  CJ’s Nuxt Crash Course.
+  
+  17:29 Core Modules and Community Modules? 
+  Nuxt Modules.
+  shadcn-nuxt.
+  @nuxt/ui.
+  DaisyUI.
+  Pinia.
+  
+  21:17 Nuxt Hosting. 
+  Deploy.
+  hub.nuxt.
+  
+  23:59 Anything you don’t like?
+  
+ Hit us up on Socials!
+  Syntax: X Instagram Tiktok LinkedIn Threads
+  Wes: X Instagram Tiktok LinkedIn Threads
+  Scott: X Instagram Tiktok LinkedIn Threads
+  Randy: X Instagram YouTube Threads</description>
+      <pubDate>Mon, 26 May 2025 00:00:00 GMT</pubDate>
+      <guid>https://syntax.fm/905</guid>
+      <enclosure url="https://traffic.libsyn.com/secure/syntax/Syntax_-_905.mp3?dest-id=532671" type="audio/mpeg" length="0"/>
+      <itunes:author>Syntax - Tasty Web Development Treats</itunes:author>
+      <itunes:summary>CJ steps in for Scott and joins Wes to share his experience working with Nuxt, from routing and data fetching to the pros and cons of the framework. They break down the Nuxt ecosystem, directory structure, and how it handles server routes and modules.
+ Show Notes
+  
+ 00:00 Syntax Meetup!
+  00:26 Welcome to Syntax
+  01:21 The deal with Nuxt. 
+  CJ’s Nuxt Course.
+  
+  02:51 Why do you like Vue?
+  04:52 Brought to you by Sentry.io.
+  05:17 Routing with Nuxt. 
+  h3 - The Web Framework for Modern JavaScript Era.
+  Nuxt Guides.
+  
+  06:12 Built on Nitro.
+  06:49 The Nuxt Ecosystem.
+  07:52 API Route Support.
+  08:15 Nuxt Directory Structure.
+  09:09 Does Nuxt do too much for you?
+  11:15 Data fetching in a Nuxt app.
+  13:25 RPC, Form Actions, Server Actions?
+  15:00 Nuxt Server Folder Hastle.
+  15:57 useFetch Hook. 
+  CJ’s Nuxt Crash Course.
+  
+  17:29 Core Modules and Community Modules? 
+  Nuxt Modules.
+  shadcn-nuxt.
+  @nuxt/ui.
+  DaisyUI.
+  Pinia.
+  
+  21:17 Nuxt Hosting. 
+  Deploy.
+  hub.nuxt.
+  
+  23:59 Anything you don’t like?
+  
+ Hit us up on Socials!
+  Syntax: X Instagram Tiktok LinkedIn Threads
+  Wes: X Instagram Tiktok LinkedIn Threads
+  Scott: X Instagram Tiktok LinkedIn Threads
+  Randy: X Instagram YouTube Threads</itunes:summary>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+  </channel>
+</rss>

--- a/scripts/generateRssXml.ts
+++ b/scripts/generateRssXml.ts
@@ -1,0 +1,137 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+// @ts-expect-error: jstoxml does not have type declarations
+import { toXML } from 'jstoxml'
+import { getLastWeeksRssUpdates } from './lastWeek' // Assuming this script is in the same /scripts directory
+import { getWeekNumber, parseWeekNumber } from '../src/utils/date' // Utility to get current week if needed
+
+const RESULTS_DIR = path.resolve(process.cwd(), 'results')
+const RSS_FILE_PATH = path.resolve(process.cwd(), 'rss.xml')
+
+async function getLatestJsonData() {
+  const files = readdirSync(RESULTS_DIR)
+    .filter(file => file.endsWith('.json') && !isNaN(parseInt(file.split('.')[0])))
+    .sort((a, b) => parseInt(b.split('.')[0]) - parseInt(a.split('.')[0]));
+
+  if (files.length === 0) {
+    console.log('No JSON files found in results directory. Fetching data for the current week.');
+    const { weekNumber } = getWeekNumber(new Date()); // Get current week number
+    return getLastWeeksRssUpdates(weekNumber);
+  }
+
+  const latestFile = files[0];
+  const filePath = path.join(RESULTS_DIR, latestFile);
+  console.log(`Using latest JSON file: ${latestFile}`);
+  const fileContent = await readFile(filePath, 'utf-8');
+  return JSON.parse(fileContent);
+}
+
+async function generateRss() {
+  try {
+    const json = await getLatestJsonData();
+
+    if (!json || !json.results) {
+      console.error('Failed to get valid JSON data.');
+      return;
+    }
+
+    const channelItems = json.results.flatMap((feed: any) =>
+      (feed.data as any[]).map((item: any) => {
+        // Try to find a publication date. Fallback to start of week.
+        // Ideally, each item in lastWeek.ts would also store its original pubDate.
+        // For now, we'll use the startOfWeek for all items in the feed for simplicity,
+        // or a more specific date if available (e.g. item.isoDate or item.pubDate from original feed processing)
+        // The current structure of results/xx.json does not store individual item pubDates.
+        // We will use startOfWeek as a general pubDate for the items of that week.
+        const itemPubDate = new Date(json.startOfWeek).toUTCString();
+
+        return {
+          item: {
+            title: item.itemTitle || 'No Title',
+            link: item.itemLink || '',
+            description: item.showNotes || item.itemTitle || 'No Description', // Use showNotes as description
+            pubDate: itemPubDate,
+            guid: item.itemLink || item.media || `${json.weekNumber}-${feed.feedTitle}-${item.itemTitle}`, // Unique GUID
+            ...(item.media
+              ? {
+                  enclosure: {
+                    _attrs: {
+                      url: item.media,
+                      type: 'audio/mpeg', // Assuming audio/mpeg, might need to be dynamic if other types are possible
+                      length: 0, // RSS best practice is to include length, but we don't have it. Set to 0.
+                    },
+                  },
+                }
+              : {}),
+            'itunes:author': feed.feedTitle,
+            'itunes:summary': item.showNotes || item.itemTitle,
+            'itunes:explicit': 'no', // Assuming content is not explicit
+            // 'itunes:duration': 'HH:MM:SS', // We don't have duration
+          },
+        };
+      })
+    );
+
+    // Filter out items that might be empty if a feed had an error or no data
+    const validChannelItems = channelItems.filter((channelItem: any) => channelItem.item.title !== 'No Title');
+
+
+    const rssObj = {
+      _name: 'rss',
+      _attrs: {
+        'version': '2.0',
+        'xmlns:atom': 'http://www.w3.org/2005/Atom',
+        'xmlns:itunes': 'http://www.itunes.com/dtds/podcast-1.0.dtd',
+        'xmlns:content': 'http://purl.org/rss/1.0/modules/content/',
+      },
+      _content: {
+        channel: [
+          {
+            'atom:link': {
+              _attrs: {
+                href: 'https://<your-domain-here>/rss.xml', // Replace with actual link to where rss.xml will be hosted
+                rel: 'self',
+                type: 'application/rss+xml',
+              },
+            },
+          },
+          { title: 'Weekly Podcast Updates' }, // General title for the feed
+          { link: 'https://<your-project-link-here>' }, // Link to the project or website
+          { language: 'en-us' }, // Assuming English, adjust if needed. The original issue was in Chinese, but the content seems to be English.
+          { description: `Weekly digest of podcast episodes from week ${json.weekNumber}, starting ${json.startOfWeek}.` },
+          { lastBuildDate: new Date().toUTCString() },
+          { pubDate: new Date(json.startOfWeek).toUTCString() }, // Publication date of the feed itself
+          // TODO: Add other optional channel elements like image, category, etc.
+          // 'itunes:author': 'Your Name/Organization',
+          // 'itunes:owner': {
+          //   'itunes:name': 'Owner Name',
+          //   'itunes:email': 'owner@example.com',
+          // },
+          // 'itunes:image': {
+          //   _attrs: {
+          //     href: 'https://<link-to-your-podcast-image.png>',
+          //   },
+          // },
+          // 'itunes:category': {
+          //   _attrs: {
+          //     text: 'Technology', // Example category
+          //   },
+          // },
+          // 'itunes:explicit': 'no',
+          ...validChannelItems,
+        ],
+      },
+    };
+
+    const xmlContent = toXML(rssObj, { header: true, indent: '  ' });
+    await writeFile(RSS_FILE_PATH, xmlContent, 'utf-8');
+    console.log(`Successfully generated rss.xml for week ${json.weekNumber}`);
+
+  } catch (e) {
+    console.error('Failed to generate RSS feed:', e);
+    process.exit(1);
+  }
+}
+
+generateRss();


### PR DESCRIPTION
This commit introduces the capability to automatically generate an RSS feed (`rss.xml`) weekly.

Key changes:
- Added a new script `scripts/generateRssXml.ts` that leverages existing podcast data fetching logic to build an RSS 2.0 feed with iTunes-specific tags. The script reads the latest weekly JSON data from the `results/` directory.
- Included `jstoxml` for XML generation.
- Added a `generate-rss` command to `package.json` to execute the new script.
- Updated the `.github/workflows/update-weekly-json.yml` GitHub Actions workflow:
    - A new step now runs the `generate-rss` script after the weekly JSON file is updated.
    - The `rss.xml` file is now included in the automated commit, along with an updated commit message for the workflow.

The generated `rss.xml` will be updated each week alongside the JSON data, providing a subscribable feed for your podcast updates.